### PR TITLE
Deploy Pulp 3 via systemd containers

### DIFF
--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -34,10 +34,12 @@
     use_regex: true
     file_type: directory
   register: result
+  when: pulp_install_dir
 
 - name: Assert the pulpcore install dir was found
   assert:
     that: '{{ result.matched }} == 1'
+  when: pulp_install_dir
 
 - block:
 
@@ -88,3 +90,4 @@
 
   become: true
   become_user: '{{ pulp_user }}'
+  when: pulp_install_dir

--- a/roles/pulp3-postgresql/tasks/main.yml
+++ b/roles/pulp3-postgresql/tasks/main.yml
@@ -34,12 +34,12 @@
     use_regex: true
     file_type: directory
   register: result
-  when: pulp_install_dir
+  when: pulp_install_dir != False
 
 - name: Assert the pulpcore install dir was found
   assert:
     that: '{{ result.matched }} == 1'
-  when: pulp_install_dir
+  when: pulp_install_dir != False
 
 - block:
 
@@ -90,4 +90,4 @@
 
   become: true
   become_user: '{{ pulp_user }}'
-  when: pulp_install_dir
+  when: pulp_install_dir != False

--- a/roles/pulp3-resource-manager/templates/pulp-resource-manager.service.j2
+++ b/roles/pulp3-resource-manager/templates/pulp-resource-manager.service.j2
@@ -1,6 +1,21 @@
 [Unit]
 Description=Pulp Resource Manager
 After=network-online.target
+{% if pulp_container_deployment %}
+Wants=syslog.service postgresql.service redis.service
+
+[Service]
+Restart=always
+RestartSec=30
+TimeoutStartSec=0
+TimeoutSec=300
+ExecStartPre=-/usr/bin/podman pull quay.io/carafe/pulp-core:{{ pulp_version }}
+ExecStartPre=-/usr/bin/podman rm "pulp-resource-manager-1"
+ExecStart=/usr/bin/podman run --name pulp-resource-manager-1 -e POSTGRES_SERVICE_HOST=localhost --net host -e REDIS_SERVICE_HOST=localhost -e REDIS_SERVICE_PORT=6379 -v /etc/pulp/settings.py:/etc/pulp/settings.py quay.io/carafe/pulp-core:{{ pulp_version }} /usr/bin/pulp-resource-manager
+ExecReload=-/usr/bin/podman stop "pulp-resource-manager-1"
+ExecReload=-/usr/bin/podman rm "pulp-resource-manager-1"
+ExecStop=-/usr/bin/podman stop "pulp-resource-manager-1"
+{% else %}
 Wants=network-online.target
 
 # This service will break if left running while PostgreSQL restarts.
@@ -15,6 +30,7 @@ RuntimeDirectory=pulp-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager@%%h \
           --pid=/var/run/pulp-resource-manager/resource-manager.pid
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pulp3-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp3-workers/templates/pulp-worker@.service.j2
@@ -1,3 +1,23 @@
+{% if pulp_container_deployment %}
+[Unit]
+Description=Pulp Worker
+Wants=syslog.service postgresql.service redis.service
+
+[Service]
+Restart=always
+RestartSec=30
+TimeoutStartSec=0
+TimeoutSec=300
+ExecStartPre=-/usr/bin/podman pull quay.io/carafe/pulp-core:{{ pulp_version }}
+ExecStartPre=-/usr/bin/podman rm "pulp-worker-%i"
+ExecStart=/usr/bin/podman run --name pulp-worker-%i -e PULP_WORKER_NUMBER=%i -e POSTGRES_SERVICE_HOST=localhost --net host -e REDIS_SERVICE_HOST=localhost -e REDIS_SERVICE_PORT=6379 -v /etc/pulp/settings.py:/etc/pulp/settings.py -v /var/lib/pulp:/var/lib/pulp quay.io/carafe/pulp-core:{{ pulp_version }} /usr/bin/pulp-worker
+ExecReload=-/usr/bin/podman stop "pulp-worker-%i"
+ExecReload=-/usr/bin/podman rm "pulp-worker-%i"
+ExecStop=-/usr/bin/podman stop "pulp-worker-%i"
+
+[Install]
+WantedBy=multi-user.target
+{% else %}
 [Unit]
 Description=Pulp RQ Worker
 After=network-online.target
@@ -21,3 +41,4 @@ ExecStart={{ pulp_install_dir }}/bin/rq worker \
 
 [Install]
 WantedBy=multi-user.target
+{% endif %}

--- a/roles/pulp3/defaults/main.yml
+++ b/roles/pulp3/defaults/main.yml
@@ -11,3 +11,5 @@ pulp_user_home: '/var/lib/pulp'
 pulp_wsgi_enabled: true
 pulp_wsgi_state: started
 pulp_pip_editable: yes
+pulp_container_deployment: false
+pulp_version: master

--- a/roles/pulp3/tasks/containers.yml
+++ b/roles/pulp3/tasks/containers.yml
@@ -1,0 +1,22 @@
+---
+- name: 'Install podman'
+  package:
+    state: present
+    name: podman
+
+- name: 'Install pulp-core container service'
+  template:
+    src: pulp_core.service.j2
+    dest: /etc/systemd/system/pulp-core.service
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+
+- name: Start pulp-core.service
+  systemd:
+    name: pulp-core.service
+    state: restarted
+    enabled: true
+    daemon_reload: true
+  become: true

--- a/roles/pulp3/tasks/main.yml
+++ b/roles/pulp3/tasks/main.yml
@@ -12,3 +12,6 @@
 - import_tasks: install.yml
 - import_tasks: configure.yml
 - import_tasks: wsgi.yml
+
+- import_tasks: containers.yml
+  when: pulp_container_deployment == true

--- a/roles/pulp3/tasks/wsgi.yml
+++ b/roles/pulp3/tasks/wsgi.yml
@@ -7,6 +7,7 @@
     virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
   become: true
   become_user: '{{ pulp_user }}'
+  when: pulp_install_dir
 
 - block:
 

--- a/roles/pulp3/tasks/wsgi.yml
+++ b/roles/pulp3/tasks/wsgi.yml
@@ -7,7 +7,7 @@
     virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
   become: true
   become_user: '{{ pulp_user }}'
-  when: pulp_install_dir
+  when: pulp_install_dir != False
 
 - block:
 

--- a/roles/pulp3/templates/pulp_core.service.j2
+++ b/roles/pulp3/templates/pulp_core.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Pulp Core
+Wants=syslog.service postgresql.service redis.service
+
+[Service]
+Restart=always
+TimeoutStartSec=0
+TimeoutSec=300
+ExecStartPre=-/usr/bin/podman pull quay.io/carafe/pulp-core:{{ pulp_version }}
+ExecStartPre=-/usr/bin/podman rm "pulp-core-1"
+ExecStart=/usr/bin/podman run --name pulp-core-1 -e POSTGRES_SERVICE_HOST=localhost --net host -v /etc/pulp/settings.py:/etc/pulp/settings.py -v /var/lib/pulp:/var/lib/pulp --publish 8000:8000 quay.io/carafe/pulp-core:{{ pulp_version }} /usr/bin/pulp-core
+ExecReload=-/usr/bin/podman stop "pulp-core-1"
+ExecReload=-/usr/bin/podman rm "pulp-core-1"
+ExecStop=-/usr/bin/podman stop "pulp-core-1"
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd-container.yaml
+++ b/systemd-container.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  become: true
+  vars:
+    pulp_secret_key: "{{ lookup('password', '/dev/null length=50 chars=ascii_letters') }}"
+    pulp_default_admin_password: password
+    pulp_install_wsgi_service: false
+    pulp_user: pulp
+    pulp_var_dir: '/var/lib/pulp'
+    pulp_wsgi_enabled: false
+    pulp_install_dir: false
+    pulp_container_deployment: true
+  roles:
+    - pulp3-postgresql
+    - pulp3-workers
+    - pulp3-resource-manager


### PR DESCRIPTION
This is a WIP by all means. However, this does generally work and hence why I am opening a starter PR for the work. This is set to work easily in conjunction with [pulplift](https://github.com/ehelms/pulplift)

```
git clone https://github.com/ehelms/pulplift
cd pulplift
./setup.sh
cd ansible-pulp3
wget https://github.com/pulp/ansible-pulp3/pull/45.patch
git am 45.patch
cd ../
vagrant up pulp3-containers-centos7
```

A few things to note about this current setup. This uses the existing containers built from my POC project repo [carafe](https://github.com/ehelms/carafe) and live on [quay.io](https://quay.io/organization/carafe/). Those containers are built from git source and include both the Ansible and File plugins. 