### PR TITLE
Support installing from github repos

### DIFF
--- a/roles/pulp-devel/defaults/main.yml
+++ b/roles/pulp-devel/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+pulp_requirements_dir: "{{ pulp_source_dir }}"
 pulp_devel_package_retries: 5
 pulp_devel_supplement_bashrc: false

--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -48,21 +48,21 @@
 
     - name: Install requirements for building docs
       pip:
-        requirements: '{{ pulp_source_dir }}/doc_requirements.txt'
+        requirements: '{{ pulp_requirements_dir }}/doc_requirements.txt'
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
     - name: Install requirements for testing locally
       pip:
-        requirements: '{{ pulp_source_dir }}/test_requirements.txt'
+        requirements: '{{ pulp_requirements_dir }}/test_requirements.txt'
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
     - name: Install requirements for developer scripts
       pip:
-        requirements: '{{ pulp_source_dir }}/dev_requirements.txt'
+        requirements: '{{ pulp_requirements_dir }}/dev_requirements.txt'
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -48,6 +48,14 @@
         owner: '{{ pulp_user }}'
         group: '{{ pulp_user }}'
 
+    - name: Install packages needed for source install
+      package:
+        name:
+          - git
+        state: present
+      register: result
+      until: result is succeeded
+
   become: true
 
 - block:


### PR DESCRIPTION
Installing while pointing to github repos mostly worked, two thing didn't
* git wasn't installed when the pip install ran
* the pip install of the various requirements.txt files failed due to 
  the assumption that pulp_source_dir was a local directory