### PR TITLE
rename pulp-wsgi

### DIFF
--- a/roles/pulp-devel/templates/alias.bashrc.j2
+++ b/roles/pulp-devel/templates/alias.bashrc.j2
@@ -1,7 +1,7 @@
 # If adding new functions to this file, note that you can add help text to the function
 # by defining a variable with name _<function>_help containing the help text
 
-SERVICES=("pulp-content-app pulp-worker@1 pulp-worker@2 pulp-resource-manager pulp-wsgi")
+SERVICES=("pulp-content-app pulp-worker@1 pulp-worker@2 pulp-resource-manager pulp-api")
 
 _paction() {
     echo systemctl $@ ${SERVICES}

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -25,18 +25,14 @@ Role Variables:
   of each plugin. **Required**.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
-* `pulp_install_wsgi_service`: Whether to create systemd service files for
-  pulp-wsgi. Defaults to "true".
+* `pulp_install_api_service`: Whether to create systemd service files for
+  pulp-api. Defaults to "true".
 * `pulp_secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
 * `pulp_source_dir`: Optional. Absolute path to Pulp source code. If present, Pulp
   will be installed from source in editable mode.
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
 * `pulp_var_dir`: This will be the home directory of the created `pulp_user`.
   Defaults to "/var/lib/pulp".
-* `pulp_wsgi_state`: This variable can be configured to any of the states allowed by
-  the systemd module's "state" directive. Defaults to "started".
-* `pulp_wsgi_enabled` This variable can be configured with any of the states allowed
-  by the systemd module's "enabled" directive. Defaults to "true."
 * `pulp_api_port` Set the port the API server is served from. Defaults to '8000'.
 * `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
 

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -6,11 +6,9 @@ pulp_db_type: 'postgres'
 pulp_default_admin_password: ''
 pulp_install_dir: '/usr/local/lib/pulp'
 pulp_install_plugins: {}
-pulp_install_wsgi_service: true
+pulp_install_api_service: true
 pulp_user: pulp
 pulp_user_home: '/var/lib/pulp'
-pulp_wsgi_enabled: true
-pulp_wsgi_state: started
 pulp_pip_editable: yes
 pulp_api_host: localhost
 pulp_api_port: 8000

--- a/roles/pulp/handlers/main.yml
+++ b/roles/pulp/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: Restart pulp-wsgi.service
+- name: Restart pulp-api.service
   systemd:
-    name: pulp-wsgi.service
+    name: pulp-api.service
     state: restarted
     daemon_reload: true
   become: true
@@ -12,3 +12,4 @@
   changed_when: "staticresult.stdout is not search('\n0 static files')"
   become: true
   become_user: '{{ pulp_user }}'
+  notify: Restart pulp-api.service

--- a/roles/pulp/tasks/wsgi.yml
+++ b/roles/pulp/tasks/wsgi.yml
@@ -10,22 +10,14 @@
 
 - block:
 
-    - name: Install pulp-wsgi service files
+    - name: Install pulp-api service files
       template:
-        src: pulp-wsgi.service.j2
-        dest: /etc/systemd/system/pulp-wsgi.service
+        src: pulp-api.service.j2
+        dest: /etc/systemd/system/pulp-api.service
         owner: root
         group: root
         mode: 0644
       become: true
-      notify: Restart pulp-wsgi.service
+      notify: Restart pulp-api.service
 
-    - name: Start pulp-wsgi.service
-      systemd:
-        name: pulp-wsgi.service
-        state: '{{ pulp_wsgi_state }}'
-        enabled: '{{ pulp_wsgi_enabled }}'
-        daemon_reload: true
-      become: true
-
-  when: pulp_install_wsgi_service
+  when: pulp_install_api_service

--- a/roles/pulp/templates/pulp-api.service.j2
+++ b/roles/pulp/templates/pulp-api.service.j2
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 User={{ pulp_user }}
-PIDFile=/run/pulp-wsgi.pid
-RuntimeDirectory=pulp-wsgi
+PIDFile=/run/pulp-api.pid
+RuntimeDirectory=pulp-api
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \
           --bind '{{ pulp_api_host }}:{{ pulp_api_port }}'
 ProtectSystem=full
@@ -18,7 +18,7 @@ PrivateDevices=yes
 # not an absolute path. PIDFile is now used to ensure that PID files are laid
 # out in a standard way. If this directive had any other effects, it is better
 # to use the correct directive than to uncomment this.
-# WorkingDirectory=/var/run/pulp-wsgi/
+# WorkingDirectory=/var/run/pulp-api/
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There was some duplicate code that I removed. The handler always restarts the service, regardless of the variables, so I removed those variables and the task to start them, instead just using the handler.

fixes #4495