### PR TITLE
Add 'make' package to install

### DIFF
--- a/roles/pulp/vars/CentOS.yml
+++ b/roles/pulp/vars/CentOS.yml
@@ -6,4 +6,5 @@ pulp_preq_packages:
   - libselinux-python  # For ansible itself
   - python-psycopg2
   - python-contextlib2
+  - make               # For make docs
 pulp_python_interpreter: /usr/bin/python36

--- a/roles/pulp/vars/Fedora.yml
+++ b/roles/pulp/vars/Fedora.yml
@@ -3,6 +3,7 @@ pulp_preq_packages:
   - python3
   - python3-devel
   - libselinux-python  # For ansible itself
+  - make               # For make docs
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
'Make' is needed when building docs, better to have it.
Added for fedora and centos as by description these are
needed to use ansible-pulp.

closes: #4585
https://pulp.plan.io/issues/4585

Signed-off-by: Pavel Picka <ppicka@redhat.com>