### PR TITLE
Add pulp_content_bind variable for pulp-content-app.service

### DIFF
--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 pulp_content_host: 'localhost:8080'
+pulp_content_bind: '0.0.0.0:8080'

--- a/roles/pulp-content/templates/pulp-content-app.service.j2
+++ b/roles/pulp-content/templates/pulp-content-app.service.j2
@@ -13,7 +13,7 @@ User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp-content-app/
 RuntimeDirectory=pulp-content-app
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \
-          --bind '{{ pulp_content_host }}' \
+          --bind '{{ pulp_content_bind }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2
 


### PR DESCRIPTION
On /etc/pulp/settings.py we need to point which CONTENT_HOST is
being used by pointing to `localhost:8080` or `fqdn:8080` this
is being added by `pulp_content_host` variable.

This same value is being used to render the `pulp-content-app.service.j2`
on its `--bind` property.

Problem:

Gunicorn fails with `example.myhost.com:8080` because it will be invalid.
Setting to the default `localhost` is also not a good idea when we need
to consume content from other hosts.

Solution:

Add a new variable `pulp_content_bind` which defaults to `0.0.0.0:8080`
thus it enabled access from any host/interface unless specified via
 `-e pulp_content_bind=...`

Having different variables for each of those settings is the best to do.

[noissue]

> NOTE: There is an email thread mentioning this problem