### PR TITLE
Change Pulp 3 Default Ports

### DIFF
--- a/roles/pulp-content/README.md
+++ b/roles/pulp-content/README.md
@@ -6,17 +6,17 @@ Install, configure, and set the state of pulp content app.
 Variables:
 ----------
 
-* `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `localhost:8080`
+* `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `localhost:24816`
 
 This variable will be set as the value of `CONTENT_HOST` config in `{{pulp_config_dir}}/settings.py` as the base path to build content URLs.
 
-Defaults to `localhost:8080`
+Defaults to `localhost:24816`
 
 * `pulp_content_bind`: Interface and Port where Pulp Content `gunicorn` service will listen.
 
 This variable is the value used to render the `pulp-content-app.service.j2` template passing to the `--bind` parameter of the gunicorn service.
 
-Defaults to `0.0.0.0:8080`
+Defaults to `0.0.0.0:24816`
 
 Shared variables:
 -----------------

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-pulp_content_host: 'localhost:8080'
-pulp_content_bind: '0.0.0.0:8080'
+pulp_content_host: 'localhost:24816'
+pulp_content_bind: '0.0.0.0:24816'

--- a/roles/pulp-devel/files/settings.json
+++ b/roles/pulp-devel/files/settings.json
@@ -4,13 +4,13 @@
       "hostname": "localhost",
       "roles": {
         "api": {
-          "port": 8000,
+          "port": 24817,
           "scheme": "http",
           "service": "nginx",
           "verify": false
         },
         "content": {
-          "port": 8080,
+          "port": 24816,
           "scheme": "http",
           "service": "pulp-content-app",
           "verify": false

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -33,7 +33,7 @@ Role Variables:
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
 * `pulp_var_dir`: This will be the home directory of the created `pulp_user`.
   Defaults to "/var/lib/pulp".
-* `pulp_api_port` Set the port the API server is served from. Defaults to '8000'.
+* `pulp_api_port` Set the port the API server is served from. Defaults to '24817'.
 * `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
 
 Shared Variables:

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -11,4 +11,4 @@ pulp_user: pulp
 pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
 pulp_api_host: localhost
-pulp_api_port: 8000
+pulp_api_port: 24817


### PR DESCRIPTION
https://pulp.plan.io/issues/4556

Content: 8080 -> 24816
API: 8000 -> 24817

Note: I am about to submit changes to pulpcore & several other repos too. The travis files exist in those other repos in addition to doc updates. They probably all need to be merged at the same time.