### PR TITLE
Start workers with the -c option

### DIFF
--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
@@ -14,7 +14,8 @@ WorkingDirectory=/var/run/pulp-resource-manager/
 RuntimeDirectory=pulp-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager@%%h \
-          --pid=/var/run/pulp-resource-manager/resource-manager.pid
+          --pid=/var/run/pulp-resource-manager/resource-manager.pid \
+          -c 'pulpcore.rqconfig'
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pulp-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulp-worker@.service.j2
@@ -17,7 +17,8 @@ RuntimeDirectory=pulp-worker-%i
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
           -n reserved-resource-worker-%i@%%h \
-          --pid=/var/run/pulp-worker-%i/reserved-resource-worker-%i.pid
+          --pid=/var/run/pulp-worker-%i/reserved-resource-worker-%i.pid \
+          -c 'pulpcore.rqconfig'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Without the -c option the systemd files won't read the RQ settings from
Pulp. This causes defualts like localhost to be the only options you can
received.

https://pulp.plan.io/issues/4732
re #4732