### PR TITLE
Problem: pulp-content-app does not produce access logs

### DIFF
--- a/roles/pulp-content/templates/pulp-content-app.service.j2
+++ b/roles/pulp-content/templates/pulp-content-app.service.j2
@@ -15,7 +15,8 @@ RuntimeDirectory=pulp-content-app
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \
           --bind '{{ pulp_content_bind }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \
-          -w 2
+          -w 2 \
+          --access-logfile -
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Solution: configure gunicorn to write access logs to stdout

fixes: #4723
https://pulp.plan.io/issues/4723