### PR TITLE
Python system-wide packages toggle

### DIFF
--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -35,6 +35,7 @@ Role Variables:
   Defaults to "/var/lib/pulp".
 * `pulp_api_port` Set the port the API server is served from. Defaults to '24817'.
 * `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
+* `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 
 Shared Variables:
 -----------------

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -12,3 +12,4 @@ pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
 pulp_api_host: localhost
 pulp_api_port: 24817
+pulp_use_system_wide_pkgs: false

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -69,6 +69,16 @@
 
 - block:
 
+    # Hack for use system-wide packages when enabled by user - Must be first usage of virtualenv
+    - name: Allow use system-wide packages
+      pip:
+        name: pip
+        state: present
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+        virtualenv_site_packages: yes
+      when: pulp_use_system_wide_pkgs
+
     - name: Install the psycopg python package
       pip:
         name: psycopg2-binary


### PR DESCRIPTION
Allow user to use python system-wide packages.

closes: #4660
https://pulp.plan.io/issues/4660

Signed-off-by: Pavel Picka <ppicka@redhat.com>