### PR TITLE
Problem: systemd unit files are in 2 locations

### DIFF
--- a/roles/pulp-resource-manager/tasks/main.yml
+++ b/roles/pulp-resource-manager/tasks/main.yml
@@ -4,7 +4,7 @@
     - name: Install service files
       template:
         src: pulp-resource-manager.service.j2
-        dest: /etc/systemd/system/pulp-resource-manager.service
+        dest: /usr/lib/systemd/system/pulp-resource-manager.service
         owner: root
         group: root
         mode: 0644

--- a/roles/pulp/tasks/wsgi.yml
+++ b/roles/pulp/tasks/wsgi.yml
@@ -13,7 +13,7 @@
     - name: Install pulp-api service files
       template:
         src: pulp-api.service.j2
-        dest: /etc/systemd/system/pulp-api.service
+        dest: /usr/lib/systemd/system/pulp-api.service
         owner: root
         group: root
         mode: 0644

--- a/roles/pulp/templates/pulp-api.service.j2
+++ b/roles/pulp/templates/pulp-api.service.j2
@@ -8,7 +8,8 @@ User={{ pulp_user }}
 PIDFile=/run/pulp-api.pid
 RuntimeDirectory=pulp-api
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \
-          --bind '{{ pulp_api_host }}:{{ pulp_api_port }}'
+          --bind '{{ pulp_api_host }}:{{ pulp_api_port }}' \
+          --access-logfile -
 ProtectSystem=full
 PrivateTmp=yes
 PrivateDevices=yes


### PR DESCRIPTION
Solution: install systemd unit files into /usr/lib/systemd

This patch also configures pulp-api service to write an access log to the console.

[noissue]