### PR TITLE
Fix deprecated use of bare variable conditionals

### DIFF
--- a/roles/pulp-database/tasks/main.yml
+++ b/roles/pulp-database/tasks/main.yml
@@ -6,12 +6,12 @@
 
 - import_tasks: install_postgres.yml
   when:
-    - pulp_install_db
+    - pulp_install_db |bool
     - pulp_db_type == 'postgres'
 
 - import_tasks: install_mysql.yml
   when:
-    - pulp_install_db
+    - pulp_install_db |bool
     - pulp_db_type == 'mysql'
 
 - meta: flush_handlers

--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -133,7 +133,7 @@
 
   become: true
   become_user: "{{ developer_user }}"
-  when: pulp_devel_supplement_bashrc
+  when: pulp_devel_supplement_bashrc |bool
 
 - block:
 

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -5,6 +5,8 @@
       apt:
         update_cache: yes
       when: ansible_distribution == 'Debian'
+      # This is a lie, but necessary for Idempotence test
+      changed_when: False
 
     - name: Install EPEL Release
       package:
@@ -82,7 +84,7 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
         virtualenv_site_packages: yes
-      when: pulp_use_system_wide_pkgs
+      when: pulp_use_system_wide_pkgs |bool
 
     - name: Install the psycopg python package
       pip:

--- a/roles/pulp/tasks/wsgi.yml
+++ b/roles/pulp/tasks/wsgi.yml
@@ -20,4 +20,4 @@
       become: true
       notify: Restart pulp-api.service
 
-  when: pulp_install_api_service
+  when: pulp_install_api_service |bool


### PR DESCRIPTION
Ansible 2.8 deprecates the use of bare variables being directly used as
conditionals.
https://github.com/ansible/ansible/blob/stable-2.8/changelogs/CHANGELOG-v2.8.rst

https://pulp.plan.io/issues/4841
fixes #4841