### PR TITLE
Extend ansible roles_path

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles


### PR DESCRIPTION
To run our example playbook in subdirectory we
need extend ansible roles_path. As ansible doesn't
allow direct extend I put there default values and
extend with roles directory. Default path must persist
as we install and use role from ansible-galaxy.

closes: #4833
https://pulp.plan.io/issues/4833

Signed-off-by: Pavel Picka <ppicka@redhat.com>