### PR TITLE
ensure static directory is owned by pulp_user

### DIFF
--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -62,6 +62,13 @@
         owner: '{{ pulp_user }}'
         group: '{{ pulp_user }}'
 
+    - name: create static dir
+      file:
+        path: '{{ pulp_user_home }}/static/'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_user }}'
+
     - name: Install packages needed for source install
       package:
         name:


### PR DESCRIPTION
On pulp2 installs, this directory already exists, owned by apache.  This prevents the collect static task from creating directories within.