### PR TITLE
Add workon/virtualenvwrapper to centos

### DIFF
--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -20,6 +20,12 @@
       register: result
       until: result is succeeded
 
+    - name: Install Centos Specific Packages
+      package:
+        name:
+          - python-virtualenvwrapper
+      when: ansible_distribution == 'CentOS'
+
     - name: Install several useful packages (Debian-specific)
       package:
         name:
@@ -129,7 +135,8 @@
       template:
         src: templates/venv.bashrc.j2
         dest: '{{ developer_user_home }}/.bashrc.d/venv.bashrc'
-      when: ansible_distribution == 'Debian' or ansible_distribution == 'Fedora'
+      when: ansible_distribution != 'Ubuntu'
+
 
   become: true
   become_user: "{{ developer_user }}"

--- a/roles/pulp-devel/templates/venv.bashrc.j2
+++ b/roles/pulp-devel/templates/venv.bashrc.j2
@@ -11,3 +11,6 @@ source /usr/bin/virtualenvwrapper-3.sh
 {% if ansible_distribution == 'Debian' %}
 export VIRTUALENVWRAPPER_HOOK_DIR=$HOME/.virtualenvs
 {% endif %}
+{% if ansible_distribution == 'CentOS' %}
+source /usr/bin/virtualenvwrapper.sh
+{% endif %}


### PR DESCRIPTION
Whatever was causing the installation problem seems to have gone away,
leaving only a minor problem that virtualenvwrapper is not installed on
CentOS so `workon pulp` didn't work.

https://pulp.plan.io/issues/4545
fixes #4545