### PR TITLE
Adds pulp_remote_user_environ_name setting

### DIFF
--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -36,6 +36,7 @@ Role Variables:
 * `pulp_api_port` Set the port the API server is served from. Defaults to '24817'.
 * `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
+* `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
 
 Shared Variables:
 -----------------

--- a/roles/pulp/templates/settings.py.j2
+++ b/roles/pulp/templates/settings.py.j2
@@ -5,3 +5,7 @@ SECRET_KEY = '{{ pulp_secret_key }}'
 {% if pulp_content_host is defined %}
 CONTENT_HOST = '{{ pulp_content_host }}'
 {% endif %}
+
+{% if pulp_remote_user_environ_name is defined %}
+REMOTE_USER_ENVIRON_NAME = '{{ pulp_remote_user_environ_name }}'
+{% endif %}


### PR DESCRIPTION
The pulp_remote_user_environ_name setting allows the user to specify the
REMOTE_USER_ENVIRON_NAME Pulp setting. This also documents the setting
in the role README.md

https://pulp.plan.io/issues/4972
closes #4972