### PR TITLE
Default to localhost bind and move var

### DIFF
--- a/roles/pulp-content/README.md
+++ b/roles/pulp-content/README.md
@@ -6,17 +6,12 @@ Install, configure, and set the state of pulp content app.
 Variables:
 ----------
 
-* `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `localhost:24816`
-
-This variable will be set as the value of `CONTENT_HOST` config in `{{pulp_config_dir}}/settings.py` as the base path to build content URLs.
-
-Defaults to `localhost:24816`
-
 * `pulp_content_bind`: Interface and Port where Pulp Content `gunicorn` service will listen.
 
-This variable is the value used to render the `pulp-content-app.service.j2` template passing to the `--bind` parameter of the gunicorn service.
+This variable is the value used to render the `pulp-content-app.service.j2` template passing to the
+`--bind` parameter of the gunicorn service.
 
-Defaults to `0.0.0.0:24816`
+Defaults to `127.0.0.1:24816`
 
 Shared variables:
 -----------------

--- a/roles/pulp-content/defaults/main.yml
+++ b/roles/pulp-content/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-pulp_content_host: 'localhost:24816'
-pulp_content_bind: '0.0.0.0:24816'
+pulp_content_bind: '127.0.0.1:24816'

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -37,6 +37,8 @@ Role Variables:
 * `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 * `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
+* `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `127.0.0.1:24816`
+  This variable will be set as the value of `CONTENT_HOST` as the base path to build content URLs.
 
 Shared Variables:
 -----------------


### PR DESCRIPTION
The pulp_content_host was being defined in pulp-content, but being used
in the 'pulp' role. This moves the setting to the pulp/README.md and
removes it from being a default specified by main.yml.

Also the pulp_content_bind is now 127.0.0.1 instead of 0.0.0.0 as part
of story 4963.

https://pulp.plan.io/issues/4963
closes #4963

https://pulp.plan.io/issues/4946
closes #4946