### PR TITLE
Allow bind and nginx to be different

### DIFF
--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -3,8 +3,22 @@ pulp-webserver
 
 Install, configure, start, and enable a web server.
 
-Currently, the only web server that this role can install is Nginx. In the
-future, additional web servers such as Apache or LightTPD might be supported.
+Currently, Nginx and Apache are supported. They are configured as a reverse proxy to the pulp-api
+and pulp-content-app Gunicorn processes.
+
+
+Variables:
+----------
+
+* `pulp_content_port` Set the port the reverse proxy should connect to for the Content app. Defaults
+  to '24816'.
+* `pulp_content_host` Set the host the reverse proxy should connect to for the Content app. Defaults
+  to '127.0.0.1'.
+* `pulp_api_port` Set the port the reverse proxy should connect to for the API server. Defaults to
+  '24817'.
+* `pulp_api_host` Set the host the reverse proxy should connect to for the API server. Defaults to
+  '127.0.0.1'.
+
 
 Shared variables:
 -----------------

--- a/roles/pulp-webserver/defaults/main.yml
+++ b/roles/pulp-webserver/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 pulp_webserver_server: nginx
+pulp_content_host: 127.0.0.1
+pulp_content_port: 24816
+pulp_api_host: 127.0.0.1
+pulp_api_port: 24817

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -33,12 +33,15 @@ Role Variables:
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
 * `pulp_var_dir`: This will be the home directory of the created `pulp_user`.
   Defaults to "/var/lib/pulp".
-* `pulp_api_port` Set the port the API server is served from. Defaults to '24817'.
-* `pulp_api_host` Set the host the API server is served from. Defaults to 'localhost'.
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 * `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
 * `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `127.0.0.1:24816`
   This variable will be set as the value of `CONTENT_HOST` as the base path to build content URLs.
+* `pulp_api_bind` Interface and Port where Pulp Content `gunicorn` service will listen. Defaults to
+  '127.0.0.1:24817'. This variable is the value used to render the `pulp-api.service.j2` template
+  passing to the `--bind` parameter of the `gunicorn` service.
+
+
 
 Shared Variables:
 -----------------

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -10,6 +10,5 @@ pulp_install_api_service: true
 pulp_user: pulp
 pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
-pulp_api_host: localhost
-pulp_api_port: 24817
 pulp_use_system_wide_pkgs: false
+pulp_api_bind: '127.0.0.1:24817'

--- a/roles/pulp/templates/pulp-api.service.j2
+++ b/roles/pulp/templates/pulp-api.service.j2
@@ -8,7 +8,7 @@ User={{ pulp_user }}
 PIDFile=/run/pulp-api.pid
 RuntimeDirectory=pulp-api
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \
-          --bind '{{ pulp_api_host }}:{{ pulp_api_port }}' \
+          --bind '{{ pulp_api_bind }}' \
           --access-logfile -
 ProtectSystem=full
 PrivateTmp=yes


### PR DESCRIPTION
This introduces a pulp_api_bind variable in the 'pulp' playbook which
the user can use to set the bind address (or multiple) of pulp-api. This
is used by the pulp-api service template for the systemd service.

It moves the nginx and apache reverse proxy variables out of the 'pulp'
playbook and into the 'pulp-webserver' playbook where they are used
exclusively. The defaults are there also. It created 4 variables:

* pulp_content_host
* pulp_content_port
* pulp_api_host
* pulp_api_port

https://pulp.plan.io/issues/4964
closes #4964