### PR TITLE
Combine all pulp django settings into single var

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ must be one of these currently supported operating systems:
 Variables
 ---------
 
-Each role documents all the variables that it uses in a separate README, and some variables are
-shared between multiple roles.
+**Each role documents all the variables that it uses in its own README**. Some variables are
+used by multiple roles. In that case, they are be documented in their primary role and mentioned in
+the `shared_variables` section the other roles.
 
 **Required Variables:**
 Most variables have sane defaults but a few are required. See ``example-use/group_vars/all`` for

--- a/example-source/group_vars/all
+++ b/example-source/group_vars/all
@@ -1,6 +1,5 @@
 ---
 pulp_default_admin_password: password
-pulp_secret_key: secret
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_plugin_source_dir: "/var/lib/pulp/devel/pulpcore-plugin"
 pulp_install_plugins:
@@ -9,3 +8,5 @@ pulp_install_plugins:
     source_dir: "/var/lib/pulp/devel/pulp_file"
 developer_user_home: /var/lib/pulp
 developer_user: pulp
+pulp_settings:
+  secret_key: secret

--- a/example-use/group_vars/all
+++ b/example-use/group_vars/all
@@ -1,6 +1,7 @@
 ---
-pulp_secret_key: secret
 pulp_default_admin_password: password
 pulp_install_plugins:
   pulp-file:
     app_label: "file"
+pulp_settings:
+  secret_key: secret

--- a/roles/pulp-database/README.md
+++ b/roles/pulp-database/README.md
@@ -1,5 +1,5 @@
-pulp3-database
-================
+pulp-database
+=============
 
 Optionally install a database, then configure for Pulp.
 
@@ -12,31 +12,29 @@ More specifically, this role does the following:
 Role Variables:
 ---------------
 
-* `pulp_database_config`: Defines how Pulp will talk to PostgreSQL. Default values are constructed
-*                         from the other variables defined here. See `defaults/main.yml`.
-* `pulp_db_host`: Host of the database instance. Defaults to localhost.
-* `pulp_db_name`: Name of the database, defaults to pulp.
-* `pulp_db_user`: Database user, should match linux user. Defaults to pulp
-* `pulp_db_password`: Password for Postgresql user. Defaults to pulp
-* `pulp_db_backend`: Django setting for db backend. for databasePassword for Postgresql user.
-                     Defaults to "django.db.backends.postgresql_psycopg2"
-* `pulp_install_db`: Defaults to true. Whether to install a database.
+* `pulp_settings_db_defaults`: This variable **should not be changed by users**, but serves as the
+    defaults. Users wishing to set their own values should use the user-facing variable
+    `pulp_settings.databases`. These settings define how Pulp will talk to the database, and
+    produces default settings for the external database installer role. Default values are defined
+    in `defaults/main.yml`. See [pulpcore
+    docs](https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#databases) or
+    [Django docs](https://docs.djangoproject.com/en/2.1/ref/settings/#databases) for more
+    information.
 
 Shared Variables:
 -----------------
 
 * `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
 
-This role **is tightly coupled** with the required the `pulp3` role and uses some of
+This role **is tightly coupled** with the required the `pulp` role and uses some of
 variables which are documented in that role:
 
+* `pulp_db_type`:
 * `pulp_user`
 * `pulp_install_dir`
 * `pulp_install_plugins`
 * `pulp_default_admin_password`
-
-
-This role optionally depends on other roles to install a database.
+* `pulp_settings`
 
 Operating Systems Variables:
 ----------------------------

--- a/roles/pulp-database/defaults/main.yml
+++ b/roles/pulp-database/defaults/main.yml
@@ -1,14 +1,12 @@
 ---
 pulp_install_db: true
-pulp_db_host: localhost
-pulp_db_name: pulp
-pulp_db_user: pulp
-pulp_db_password: pulp
-pulp_db_backend: django.db.backends.postgresql_psycopg2
-pulp_database_config:
-  default:
-    HOST: "{{ pulp_db_host }}"
-    ENGINE: "{{ pulp_db_backend }}"
-    NAME: "{{ pulp_db_name}}"
-    USER: "{{ pulp_db_user }}"
-    PASSWORD: "{{ pulp_db_password }}"
+
+# Users should not set this variable, instead using `pulp_settings.databases`
+pulp_settings_db_defaults:
+    databases:
+        default:
+            HOST: localhost
+            ENGINE: django.db.backends.postgresql_psycopg2
+            NAME: pulp
+            USER: pulp
+            PASSWORD: pulp

--- a/roles/pulp-database/tasks/install_postgres.yml
+++ b/roles/pulp-database/tasks/install_postgres.yml
@@ -11,7 +11,7 @@
         postgresql_global_config_options:
           - option: listen_addresses
             value: "*"
-      when: pulp_db_host != 'localhost'
+      when: pulp_settings.databases.default.HOST != 'localhost'
 
     - name: Install and configure PostgreSQL
       import_role:

--- a/roles/pulp-database/vars/main.yml
+++ b/roles/pulp-database/vars/main.yml
@@ -2,10 +2,10 @@
 # Variables used by the Geerlingguy Postgresql role
 
 postgresql_databases:
-  - name: '{{ pulp_database_config["default"]["NAME"] }}'
-    owner: '{{ pulp_database_config["default"]["NAME"] }}'
+  - name: '{{ pulp_settings.databases.default.NAME }}'
+    owner: '{{ pulp_settings.databases.default.NAME }}'
 
 postgresql_users:
-  - name: '{{ pulp_database_config["default"]["USER"] }}'
-    password: '{{ pulp_database_config["default"]["PASSWORD"] }}'
+  - name: '{{ pulp_settings.databases.default.USER }}'
+    password: '{{ pulp_settings.databases.default.PASSWORD }}'
     role_attr_flags: CREATEDB

--- a/roles/pulp-devel/README.md
+++ b/roles/pulp-devel/README.md
@@ -1,5 +1,5 @@
-Pulp3 Devel
-===========
+pulp-devel
+==========
 
 This role installs useful tools and adds some config files for a Pulp 3
 development environment.

--- a/roles/pulp-redis/README.md
+++ b/roles/pulp-redis/README.md
@@ -1,5 +1,5 @@
 pulp-redis
-===========
+==========
 
 Install and start Redis, and install RQ in the Pulp virtualenv.
 

--- a/roles/pulp-resource-manager/README.md
+++ b/roles/pulp-resource-manager/README.md
@@ -1,5 +1,5 @@
 pulp-resource-manager
-=============
+=====================
 
 Install, configure, and set the state of the pulp resouce manager.
 

--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -1,5 +1,5 @@
 pulp-webserver
-===============
+==============
 
 Install, configure, start, and enable a web server.
 

--- a/roles/pulp-workers/README.md
+++ b/roles/pulp-workers/README.md
@@ -1,5 +1,5 @@
 pulp-workers
-=============
+============
 
 Install, configure, and set the state of pulp workers.
 

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -1,5 +1,5 @@
-Pulp3
-=====
+Pulp
+====
 
 Ansible role that installs Pulp 3 from PyPi or source and provides basic config.
 
@@ -11,8 +11,7 @@ Role Variables:
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to "/var/lib/pulp/tmp".
 * `pulp_config_dir`: Directory which will contain Pulp configuration files.
   Defaults to "/etc/pulp".
-* `pulp_db_type`: Type of db to install packages for. Options are postgres
-  or mysql. Default is postgres.
+* `pulp_db_type`: Type of db to install packages for. Options are `postgres` (default) or `mysql`
 * `pulp_default_admin_password`: Initial password for the Pulp admin. **Required**.
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
@@ -27,20 +26,21 @@ Role Variables:
   plugin will be installed from source in editable mode.
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulp-api. Defaults to "true".
-* `pulp_secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
 * `pulp_source_dir`: Optional. Absolute path to Pulp source code. If present, Pulp
   will be installed from source in editable mode.
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
-* `pulp_var_dir`: This will be the home directory of the created `pulp_user`.
-  Defaults to "/var/lib/pulp".
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 * `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
-* `pulp_content_host`: Host and port where Pulp content app is served. Defaults to `127.0.0.1:24816`
   This variable will be set as the value of `CONTENT_HOST` as the base path to build content URLs.
 * `pulp_api_bind` Interface and Port where Pulp Content `gunicorn` service will listen. Defaults to
   '127.0.0.1:24817'. This variable is the value used to render the `pulp-api.service.j2` template
   passing to the `--bind` parameter of the `gunicorn` service.
-
+* `pulp_settings`: A nested dictionary that is used to add custom values to the user's
+    `setting.py`, which will override any default values set by pulpcore. The keys of this
+    dictionary are variable names, and the values can be nested. Please see [pulpcore configuration
+    docs](https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#id2) for
+    documentation on the possible values.
+  * `pulp_settings.secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
 
 
 Shared Variables:
@@ -48,10 +48,9 @@ Shared Variables:
 
 * `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
 
-This role is required by the `pulp-postgresql` role and uses variables that
-are defined and documented in that role:
+This role is required by the `pulp-database` role and uses some variables from it.
 
-* `pulp_database_config`
+* `pulp_settings_db_defaults`: See pulp-database README.
 
 
 Operating System Variables:

--- a/roles/pulp/tasks/configure.yml
+++ b/roles/pulp/tasks/configure.yml
@@ -1,21 +1,26 @@
 ---
+
+- name: Set database defaults if not provided
+  set_fact:
+    pulp_settings: "{{ pulp_settings_db_defaults|combine(pulp_settings, recursive=True) }}"
+
 - block:
 
-  - name: Create configuration directory for Pulp
-    file:
-      path: '{{ pulp_config_dir }}'
-      state: directory
-      owner: root
-      group: '{{ pulp_user }}'
-      mode: 0750
+    - name: Create configuration directory for Pulp
+      file:
+        path: '{{ pulp_config_dir }}'
+        state: directory
+        owner: root
+        group: '{{ pulp_user }}'
+        mode: 0750
 
-  - name: Create configuration file for Pulp
-    template:
-      src: settings.py.j2
-      dest: '{{ pulp_config_dir }}/settings.py'
-      owner: root
-      group: '{{ pulp_user }}'
-      mode: 0640
-      force: no
+    - name: Create configuration file for Pulp
+      template:
+        src: settings.py.j2
+        dest: '{{ pulp_config_dir }}/settings.py'
+        owner: root
+        group: '{{ pulp_user }}'
+        mode: 0640
+        force: no
 
   become: true

--- a/roles/pulp/tasks/main.yml
+++ b/roles/pulp/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Fail when pulp_secret_key is not set
   assert:
-    that: pulp_secret_key is defined
+    that: pulp_settings.secret_key is defined
 
 - name: Load OS specific variables
   include_vars: '{{ ansible_distribution }}.yml'

--- a/roles/pulp/templates/settings.py.j2
+++ b/roles/pulp/templates/settings.py.j2
@@ -1,11 +1,3 @@
-DATABASES = {{ pulp_database_config | to_json }}
-
-SECRET_KEY = '{{ pulp_secret_key }}'
-
-{% if pulp_content_host is defined %}
-CONTENT_HOST = '{{ pulp_content_host }}'
-{% endif %}
-
-{% if pulp_remote_user_environ_name is defined %}
-REMOTE_USER_ENVIRON_NAME = '{{ pulp_remote_user_environ_name }}'
-{% endif %}
+{% for setting, value in pulp_settings.items() %}
+{{ setting | upper }} = {{ value | tojson }}
+{% endfor %}


### PR DESCRIPTION
By creating a dictionary `pulp_settings` we can allow users to add or
update arbitrary values which will go into their local settings.py. This
also creates a clear scope separation between ansible variables and pulp
settings variables.

https://pulp.plan.io/issues/5031
fixes #5031