### PR TITLE
Problem: Pulp 2 stops working after installing Pulp 3

### DIFF
--- a/roles/pulp-database/tasks/main.yml
+++ b/roles/pulp-database/tasks/main.yml
@@ -35,7 +35,7 @@
         name: '{{ result.files[0].path }}/site-packages/pulpcore/app/migrations'
         state: directory
         owner: '{{ pulp_user }}'
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
         mode: 0700
       when: pulp_source_dir is undefined
 
@@ -44,7 +44,7 @@
         name: '{{ result.files[0].path }}/site-packages/{{ item }}/app/migrations'
         state: directory
         owner: '{{ pulp_user }}'
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
         mode: 0700
       with_items: "{{ pulp_install_plugins }}"
       when: pulp_install_plugins[item].source_dir is undefined

--- a/roles/pulp-database/vars/main.yml
+++ b/roles/pulp-database/vars/main.yml
@@ -3,7 +3,7 @@
 
 postgresql_databases:
   - name: '{{ merged_pulp_settings.databases.default.NAME }}'
-    owner: '{{ merged_pulp_settings.databases.default.NAME }}'
+    owner: '{{ merged_pulp_settings.databases.default.USER }}'
 
 postgresql_users:
   - name: '{{ merged_pulp_settings.databases.default.USER }}'

--- a/roles/pulp-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulp-worker@.service.j2
@@ -8,6 +8,7 @@ EnvironmentFile=-/etc/default/pulp-workers
 EnvironmentFile=-/etc/default/pulp-workers-%i
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 User={{ pulp_user }}
+Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulp-worker-%i/
 RuntimeDirectory=pulp-worker-%i
 ExecStart={{ pulp_install_dir }}/bin/rq worker \

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -29,6 +29,11 @@ Role Variables:
 * `pulp_source_dir`: Optional. Absolute path to Pulp source code. If present, Pulp
   will be installed from source in editable mode.
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
+* `pulp_user_id`: Integer value of uid for the `pulp_user`. Defaults to nothing and uid is assigned
+  by the system.
+* `pulp_group`: The group that the `pulp_user` belongs to. Defaults to `pulp`.
+* `pulp_group_id`: Integer value of gid for the `pulp_group`. Defaults to nothing and gid is
+  assigned by the system.
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 * `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
   This variable will be set as the value of `CONTENT_HOST` as the base path to build content URLs.

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -8,6 +8,9 @@ pulp_install_dir: '/usr/local/lib/pulp'
 pulp_install_plugins: {}
 pulp_install_api_service: true
 pulp_user: pulp
+pulp_user_id:
+pulp_group: pulp
+pulp_group_id:
 pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false

--- a/roles/pulp/tasks/configure.yml
+++ b/roles/pulp/tasks/configure.yml
@@ -10,7 +10,7 @@
         path: '{{ pulp_config_dir }}'
         state: directory
         owner: root
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
         mode: 0750
 
     - name: Create configuration file for Pulp
@@ -18,7 +18,7 @@
         src: settings.py.j2
         dest: '{{ pulp_config_dir }}/settings.py'
         owner: root
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
         mode: 0640
         force: no
 

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -41,20 +41,46 @@
       check_mode: False
       register: result
 
+    - name: Make sure {{ pulp_group }} group exists
+      group:
+        name: '{{ pulp_group }}'
+        gid: '{{ pulp_group_id }}'
+        state: present
+        system: true
+
     - name: Create user {{ pulp_user }}
       user:
         name: '{{ pulp_user }}'
+        uid: '{{ pulp_user_id }}'
         shell: '{{ result.stdout.strip() }}'
         home: '{{ pulp_user_home }}'
         system: true
       when: developer_user is not defined
+
+    - name: Add user {{ pulp_user }} to {{ pulp_group }} group
+      user:
+        name: '{{ pulp_user }}'
+        groups:
+          - '{{ pulp_group }}'
+        append: true
+
+    - name: Add user {{ developer_user }} to {{ pulp_group }} group
+      user:
+        name: '{{ developer_user }}'
+        groups:
+          - '{{ pulp_group }}'
+        append: true
+      when: developer_user is defined
+
+    - name: Reset ssh conn to allow user changes to affect when ssh user and pulp user are the same
+      meta: reset_connection
 
     - name: Create cache dir for Pulp
       file:
         path: '{{ pulp_cache_dir }}'
         state: directory
         owner: '{{ pulp_user }}'
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
         mode: 0775
 
     - name: Create pulp install dir
@@ -62,7 +88,7 @@
         path: '{{ pulp_install_dir }}'
         state: directory
         owner: '{{ pulp_user }}'
-        group: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
 
     - name: Install packages needed for source install
       package:


### PR DESCRIPTION
Solution: make use of the 'pulp' group when setting permissions

Pulp 2.20 changed ownership of /var/lib/pulp and /etc/pulp from group 'apache' to group
'pulp'. This change to the installer ensures that the permissions on these directories
remain the same after the installer runs on a machine that already has Pulp 2 installed.

This patch ensures that the 'pulp_user' is added to the 'pulp' group. The connection is
reset after this to support installations where the ssh user being used for ansible is the
same as the pulp_user. This allows the user changes to affect.

closes: #5104
https://pulp.plan.io/issues/5104