### PR TITLE
Add PostgreSQL 9.6 for CentOS7

### DIFF
--- a/roles/pulp-content/templates/pulp-content-app.service.j2
+++ b/roles/pulp-content/templates/pulp-content-app.service.j2
@@ -3,10 +3,6 @@ Description=Pulp Content App
 After=network-online.target
 Wants=network-online.target
 
-# This service will break if left running while PostgreSQL restarts.
-BindsTo=postgresql.service
-After=postgresql.service
-
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 User={{ pulp_user }}
@@ -17,6 +13,12 @@ ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2 \
           --access-logfile -
+
+
+# This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either
+# is not available at startup or becomes disconnected, this process will die and not respawn.
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pulp-database/tasks/install_postgres.yml
+++ b/roles/pulp-database/tasks/install_postgres.yml
@@ -6,6 +6,12 @@
         state: present
       when: ansible_distribution == 'CentOS'
 
+    - name: Install PostgreSQL SCL
+      package:
+        name: 'rh-postgresql96'
+        state: present
+      when: ansible_distribution == 'CentOS'
+
     - name: Set listen addresses
       set_fact:
         postgresql_global_config_options:

--- a/roles/pulp-database/vars/CentOS.yml
+++ b/roles/pulp-database/vars/CentOS.yml
@@ -1,2 +1,9 @@
 ---
 postgresql_python_library: python-psycopg2
+
+# vars needed for 'rh-postgresql96' SCL
+postgresql_packages: rh-postgresql96
+postgresql_daemon: rh-postgresql96-postgresql
+postgresql_bin_path: /opt/rh/rh-postgresql96/root/bin
+postgresql_data_dir: /var/opt/rh/rh-postgresql96/lib/pgsql/data
+postgresql_config_path: /var/opt/rh/rh-postgresql96/lib/pgsql/data

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
@@ -3,10 +3,6 @@ Description=Pulp Resource Manager
 After=network-online.target
 Wants=network-online.target
 
-# This service will break if left running while PostgreSQL restarts.
-BindsTo=postgresql.service
-After=postgresql.service
-
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 User={{ pulp_user }}
@@ -16,6 +12,12 @@ ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager@%%h \
           --pid=/var/run/pulp-resource-manager/resource-manager.pid \
           -c 'pulpcore.rqconfig'
+
+
+# This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either
+# is not available at startup or becomes disconnected, this process will die and not respawn.
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pulp-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulp-worker@.service.j2
@@ -3,10 +3,6 @@ Description=Pulp RQ Worker
 After=network-online.target
 Wants=network-online.target
 
-# This service will break if left running while PostgreSQL restarts.
-BindsTo=postgresql.service
-After=postgresql.service
-
 [Service]
 EnvironmentFile=-/etc/default/pulp-workers
 EnvironmentFile=-/etc/default/pulp-workers-%i
@@ -19,6 +15,12 @@ ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -n reserved-resource-worker-%i@%%h \
           --pid=/var/run/pulp-worker-%i/reserved-resource-worker-%i.pid \
           -c 'pulpcore.rqconfig'
+
+
+# This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either
+# is not available at startup or becomes disconnected, this process will die and not respawn.
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/pulp/templates/pulp-api.service.j2
+++ b/roles/pulp/templates/pulp-api.service.j2
@@ -14,6 +14,12 @@ ProtectSystem=full
 PrivateTmp=yes
 PrivateDevices=yes
 
+
+# This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either
+# is not available at startup or becomes disconnected, this process will die and not respawn.
+Restart=always
+RestartSec=3
+
 # This directive is set to an absolute path in other Pulp units. Using an
 # absolute path is an abuse of the directive, as it should be a relative path,
 # not an absolute path. PIDFile is now used to ensure that PID files are laid


### PR DESCRIPTION
Pulp is requiring PostgreSQL 9.6 with Django 2.2 (LTS). This upgrades
the version of PostgreSQL on CentOS 7 to 9.6 via software collections.

The systemd files can no longer depend on the postgresql service name to
restart them when postgresql restarts. Foremost because we can't be
guaranteed postgresql is a systemd unit on this system. Secondly due to
this PR that name is now changing on centos7.

This PR removes the systemd dependency on postgresql service units and
instead configures all Pulp services to automatically always restart
when it exits. Stopping the unit with systemctl still stops it.

https://pulp.plan.io/issues/5147
closes #5147
