### PR TITLE
Update README.md for supported Fedora versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ must have Python 3 and Ansible installed.
 
 The [managed node](https://docs.ansible.com/ansible/2.5/network/getting_started/basic_concepts.html#managed-nodes)
 must be one of these currently supported operating systems:
-* Fedora 28
 * CentOS 7
+* Fedora 29 or later
+* Fedora 28 (deprecated)
 
 Variables
 ---------


### PR DESCRIPTION
[noissue]

Note: My theory is that any plugin without any C deps will run fine on Fedora 28.

But plugins that do (like RPM) are likely to be broken on Fedora 28, since it is end of life.