### PR TITLE
Prevent rq from logging secrets

### DIFF
--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
@@ -11,7 +11,8 @@ RuntimeDirectory=pulp-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager@%%h \
           --pid=/var/run/pulp-resource-manager/resource-manager.pid \
-          -c 'pulpcore.rqconfig'
+          -c 'pulpcore.rqconfig' \
+          --disable-job-desc-logging
 
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either

--- a/roles/pulp-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulp-worker@.service.j2
@@ -15,7 +15,8 @@ ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
           -n reserved-resource-worker-%i@%%h \
           --pid=/var/run/pulp-worker-%i/reserved-resource-worker-%i.pid \
-          -c 'pulpcore.rqconfig'
+          -c 'pulpcore.rqconfig' \
+          --disable-job-desc-logging
 
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either


### PR DESCRIPTION
Though the issue is specific about certain cases that shouldn't be
logged, we do not have fine control over what rq logs, so the solution
is to disable logging of the description (which includes the job
arguments).

https://pulp.plan.io/issues/5012
fixes #5012