### PR TITLE
Add function for cleaning .pyc .pyo and cache

### DIFF
--- a/roles/pulp-devel/templates/alias.bashrc.j2
+++ b/roles/pulp-devel/templates/alias.bashrc.j2
@@ -118,4 +118,4 @@ pyclean () {
         find . -type f -name "*.py[co]" -delete
         find . -type d -name "__pycache__" -delete
 }
-_phelp_help="Cleanup extra python files"
+_pyclean_help="Cleanup extra python files"

--- a/roles/pulp-devel/templates/alias.bashrc.j2
+++ b/roles/pulp-devel/templates/alias.bashrc.j2
@@ -113,3 +113,9 @@ phelp() {
     setterm -default
 }
 _phelp_help="Print this help"
+
+pyclean () {
+        find . -type f -name "*.py[co]" -delete
+        find . -type d -name "__pycache__" -delete
+}
+_phelp_help="Cleanup extra python files"


### PR DESCRIPTION
When developing smash tests, I they frequently run against a previous
version of the file. I assume this is pyc related. This is a minor
annoyance but an easy fix.

[noissue]