### PR TITLE
Install JWT authentication plugin for HTTPie

### DIFF
--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -7,7 +7,6 @@
           - dstat
           - git
           - htop
-          - httpie
           - iotop
           - jnettop
           - jq
@@ -87,6 +86,15 @@
     - name: Install requirements for developer scripts
       pip:
         requirements: '{{ pulp_requirements_dir }}/dev_requirements.txt'
+        state: present
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+
+    - name: Install HTTPie and JWT authentication plugin
+      pip:
+        name:
+          - httpie
+          - httpie-jwt-auth
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'


### PR DESCRIPTION
The plugin is required for querying the pulp content server
with Json Web Token authorization headers. HTTPie uses a
configuration provided by .netrc by default. A custom
Authorization header is always overwritten by this
configuration.

This change is relevant to pulp_docker plugin, where an
authenticated registry for a content pulling/pushing is
going to be implemented, and HTTPie is the recommended
tool to perform API requests.

[noissue]