### PR TITLE
CentOS 7 Python interpreter name change

### DIFF
--- a/roles/pulp/vars/CentOS.yml
+++ b/roles/pulp/vars/CentOS.yml
@@ -7,4 +7,4 @@ pulp_preq_packages:
   - python-psycopg2
   - python-contextlib2
   - make               # For make docs
-pulp_python_interpreter: /usr/bin/python36
+pulp_python_interpreter: /usr/bin/python3.6


### PR DESCRIPTION
We use the CentOS 7 CR repo and noticed that the Python 3.6 interpreter name changed.  This will get into main CentOS 7 eventually anyway so it'll be good to change it.