### PR TITLE
Add "pulp_extra_groups" variable and functionality to "pulp" role

### DIFF
--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -30,6 +30,8 @@ Role Variables:
 * `pulp_group`: The group that the `pulp_user` belongs to. Defaults to `pulp`.
 * `pulp_group_id`: Integer value of gid for the `pulp_group`. Defaults to nothing and gid is
   assigned by the system.
+* `pulp_extra_groups`: Optional. A list of additional group names that the `pulp_user` should
+  be added to. This is site-specific and defaults to nothing.
 * `pulp_use_system_wide_pkgs` Use python system-wide packages. Defaults to "false".
 * `pulp_remote_user_environ_name` Optional. Set the `REMOTE_USER_ENVIRON_NAME` setting for Pulp.
   This variable will be set as the value of `CONTENT_HOST` as the base path to build content URLs.

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -64,6 +64,13 @@
           - '{{ pulp_group }}'
         append: true
 
+    - name: Add user {{ pulp_user }} to extra groups
+      user:
+        name: '{{ pulp_user }}'
+        groups: '{{ pulp_extra_groups }}'
+        append: true
+      when: pulp_extra_groups is defined
+
     - name: Add user {{ developer_user }} to {{ pulp_group }} group
       user:
         name: '{{ developer_user }}'


### PR DESCRIPTION
In our environment, there are additional groups the pulp user must be added to during installation. For example, the Python binary we wish to use is only executable by a certain group. In order to facilitate this, I've added an optional variable, "pulp_extra_groups". If defined, the pulp role will add the pulp user to groups in this list. I think this is probably a reasonably common use case.

Thanks!