### PR TITLE
Problem: journalctl doesn't work for vagrant user in pulp2-pulp3 dev box

### DIFF
--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -60,13 +60,11 @@
       until: result is succeeded
       when: ansible_distribution == 'Fedora'
 
-    - name: "Add {{ pulp_user }} to systemd-journal group (Debian only)"
+    - name: "Add {{ pulp_user }} to systemd-journal group"
       user:
         name: "{{ pulp_user }}"
         groups: systemd-journal
         append: yes
-      when: ansible_distribution == 'Debian'
-
 
   become: true
 


### PR DESCRIPTION
Solution: Add the pulp_user (vagrant) to systemd-journal group in all
distros, not just Debian.
This is in the pulp-devel role, so will not affect end users.

Fixes: #5272
journalctl doesn't work for vagrant user in pulp2-pulp3 dev box
https://pulp.plan.io/issues/5272