### PR TITLE
Add virtualenv /bin/ to systemd PATH

### DIFF
--- a/roles/pulp-content/templates/pulp-content-app.service.j2
+++ b/roles/pulp-content/templates/pulp-content-app.service.j2
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PATH={{ pulp_install_dir }}/bin:{{ ansible_env.PATH }}"
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp-content-app/
 RuntimeDirectory=pulp-content-app

--- a/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulp-resource-manager.service.j2
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PATH={{ pulp_install_dir }}/bin:{{ ansible_env.PATH }}"
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulp-resource-manager/
 RuntimeDirectory=pulp-resource-manager

--- a/roles/pulp-workers/templates/pulp-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulp-worker@.service.j2
@@ -7,6 +7,7 @@ Wants=network-online.target
 EnvironmentFile=-/etc/default/pulp-workers
 EnvironmentFile=-/etc/default/pulp-workers-%i
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PATH={{ pulp_install_dir }}/bin:{{ ansible_env.PATH }}"
 User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulp-worker-%i/

--- a/roles/pulp/templates/pulp-api.service.j2
+++ b/roles/pulp/templates/pulp-api.service.j2
@@ -4,6 +4,8 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PATH={{ pulp_install_dir }}/bin:{{ ansible_env.PATH }}"
 User={{ pulp_user }}
 PIDFile=/run/pulp-api.pid
 RuntimeDirectory=pulp-api


### PR DESCRIPTION
The systemd files did not manipulate the binary, so the Python import
would be inside the virtualenv a call to `subprocess` would not.

https://pulp.plan.io/issues/5474
closes #5474