### PR TITLE
Problem: Travis CI is failing on CentOS 7.7 for the firewalld module

### DIFF
--- a/molecule/scenario_resources/host_vars/centos-7
+++ b/molecule/scenario_resources/host_vars/centos-7
@@ -1,1 +1,1 @@
-pulp_configure_firewall: none
+pulp_configure_firewall: firewalld

--- a/roles/pulp-webserver/tasks/firewalld.yml
+++ b/roles/pulp-webserver/tasks/firewalld.yml
@@ -11,6 +11,14 @@
         name: firewalld
         state: started
         enabled: true
+      register: firewalld_service
+
+    # Workaround dbus ServiceUnknown error in firewalld module.
+    # Observed on CentOS 7.7, but is an issue in general.
+    # https://github.com/dw/mitogen/issues/570#issuecomment-475754758
+    - name: Reset connection
+      meta: reset_connection
+      when: firewalld_service.changed
 
     - name: Accept connections on port 80
       firewalld:

--- a/roles/pulp-webserver/tasks/firewalld.yml
+++ b/roles/pulp-webserver/tasks/firewalld.yml
@@ -1,6 +1,18 @@
 ---
 - block:
 
+    # Ansible molecule disables a bunch of services by modifying /usr/lib/system
+    # (it's not supposed to modify /usr though.)
+    # And also does yum update, which re-enables many, leaving the system in an
+    # inconsistent state.
+    # For EL 7.6 images upgraded to EL 7.7, we need this enabled for the
+    # firewalld ansible module to work.
+    - name: Start and enable dbus
+      systemd:
+        name: dbus
+        state: started
+        enabled: true
+
     - name: Install firewalld
       package:
         name: firewalld


### PR DESCRIPTION
Solution: reset ansible's connection if the service is changed.