### PR TITLE
Add "pulp_configure_firewalld" variable and functionality to "pulp-webserver" role

### DIFF
--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -18,6 +18,7 @@ Variables:
   '24817'.
 * `pulp_api_host` Set the host the reverse proxy should connect to for the API server. Defaults to
   '127.0.0.1'.
+* `pulp_configure_firewalld` Install and configure firewalld. Defaults to 'true'.
 
 
 Shared variables:

--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -18,7 +18,8 @@ Variables:
   '24817'.
 * `pulp_api_host` Set the host the reverse proxy should connect to for the API server. Defaults to
   '127.0.0.1'.
-* `pulp_configure_firewalld` Install and configure firewalld. Defaults to 'true'.
+* `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
+  and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
 
 
 Shared variables:

--- a/roles/pulp-webserver/defaults/main.yml
+++ b/roles/pulp-webserver/defaults/main.yml
@@ -4,4 +4,4 @@ pulp_content_host: 127.0.0.1
 pulp_content_port: 24816
 pulp_api_host: 127.0.0.1
 pulp_api_port: 24817
-pulp_configure_firewalld: true
+pulp_configure_firewall: auto

--- a/roles/pulp-webserver/defaults/main.yml
+++ b/roles/pulp-webserver/defaults/main.yml
@@ -4,3 +4,4 @@ pulp_content_host: 127.0.0.1
 pulp_content_port: 24816
 pulp_api_host: 127.0.0.1
 pulp_api_port: 24817
+pulp_configure_firewalld: true

--- a/roles/pulp-webserver/tasks/apache.yml
+++ b/roles/pulp-webserver/tasks/apache.yml
@@ -15,6 +15,11 @@
   set_fact:
     pulp_webserver_static_dir: '{{ result.files[0].path }}/rest_framework'
 
+- name: Set default firewall
+  set_fact:
+    pulp_configure_firewall: 'firewalld'
+  when: pulp_configure_firewall == 'auto'
+
 - block:
 
     - name: Install Apache
@@ -38,14 +43,14 @@
       package:
         name: firewalld
         state: present
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
     - name: Start and enable firewalld
       systemd:
         name: firewalld
         state: started
         enabled: true
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
     - name: Accept connections on port 80
       firewalld:
@@ -53,6 +58,6 @@
         permanent: true
         immediate: true
         state: enabled
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
   become: true

--- a/roles/pulp-webserver/tasks/apache.yml
+++ b/roles/pulp-webserver/tasks/apache.yml
@@ -38,12 +38,14 @@
       package:
         name: firewalld
         state: present
+      when: pulp_configure_firewalld
 
     - name: Start and enable firewalld
       systemd:
         name: firewalld
         state: started
         enabled: true
+      when: pulp_configure_firewalld
 
     - name: Accept connections on port 80
       firewalld:
@@ -51,5 +53,6 @@
         permanent: true
         immediate: true
         state: enabled
+      when: pulp_configure_firewalld
 
   become: true

--- a/roles/pulp-webserver/tasks/nginx.yml
+++ b/roles/pulp-webserver/tasks/nginx.yml
@@ -23,6 +23,11 @@
   set_fact:
     pulp_webserver_static_dir: '{{ result.files[0].path }}/rest_framework'
 
+- name: Set default firewall
+  set_fact:
+    pulp_configure_firewall: 'firewalld'
+  when: pulp_configure_firewall == 'auto'
+
 - block:
 
     - name: Install Nginx
@@ -47,14 +52,14 @@
       package:
         name: firewalld
         state: present
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
     - name: Start and enable firewalld
       systemd:
         name: firewalld
         state: started
         enabled: true
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
     - name: Accept connections on port 80
       firewalld:
@@ -62,6 +67,6 @@
         permanent: true
         immediate: true
         state: enabled
-      when: pulp_configure_firewalld
+      when: pulp_configure_firewall == 'firewalld'
 
   become: true

--- a/roles/pulp-webserver/tasks/nginx.yml
+++ b/roles/pulp-webserver/tasks/nginx.yml
@@ -47,12 +47,14 @@
       package:
         name: firewalld
         state: present
+      when: pulp_configure_firewalld
 
     - name: Start and enable firewalld
       systemd:
         name: firewalld
         state: started
         enabled: true
+      when: pulp_configure_firewalld
 
     - name: Accept connections on port 80
       firewalld:
@@ -60,5 +62,6 @@
         permanent: true
         immediate: true
         state: enabled
+      when: pulp_configure_firewalld
 
   become: true


### PR DESCRIPTION
The "pulp-webserver" role installs and configures firewalld. However, in many environments, firewalld is not used or is configured separately. To support this, I've added a variable "pulp_configure_firewalld" which defaults to "true" and controls the install/config of firewalld tasks.