### PR TITLE
Problem: installer fails on el7 installing pulp_rpm

### DIFF
--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -14,6 +14,9 @@ Role Variables:
 * `pulp_default_admin_password`: Initial password for the Pulp admin. **Required**.
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
+* `prereq_pip_packages`: Additional pip packages to install in the virtual
+  environment before installing pulp or its content plugins.
+  Defaults to an empty list, but plugin prerequisite roles may append to it.
 * `pulp_install_plugins`: A nested dictionary of plugin configuration options.
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -14,3 +14,4 @@ pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 pulp_api_bind: '127.0.0.1:24817'
+prereq_pip_packages: []

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -119,6 +119,14 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
+    - name: Install the prereq_pip_packages
+      pip:
+        name: '{{ prereq_pip_packages }}'
+        state: present
+        virtualenv: '{{ pulp_install_dir }}'
+        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+      when: prereq_pip_packages | length > 0
+
     - name: Install pulpcore package from source
       pip:
         name: '{{ pulp_source_dir }}'


### PR DESCRIPTION
Solution: Install a list of python packages from
pulp-rpm-prerequisites within the venv.
    
Fixes: #5496
Installer fails on el7 installing pulp_rpm
https://pulp.plan.io/issues/5496
    
Required PR: https://github.com/pulp/pulp-rpm-prerequisites/pull/9

NOTE: This PR is based on https://github.com/pulp/ansible-pulp/pull/164 . Please merge that 1st.