### PR TITLE
Problem: Running include_roles with pulp_rpm_prerequisites causes it …

### DIFF
--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -14,15 +14,15 @@ Role Variables:
 * `pulp_default_admin_password`: Initial password for the Pulp admin. **Required**.
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
-* `prereq_pip_packages`: Additional pip packages to install in the virtual
-  environment before installing pulp or its content plugins.
-  Defaults to an empty list, but plugin prerequisite roles may append to it.
 * `pulp_install_plugins`: A nested dictionary of plugin configuration options.
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each
   plugin's* `setup.py`. **Required**.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
+  * `prereq_role`: Optional. Name of Ansible role to run immediately before the
+    venv is created. Needed because many plugins will have OS dependencies in C.
+    See `prereq_pip_packages` also.
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulp-api. Defaults to "true".
 * `pulp_source_dir`: Optional. Absolute path to Pulp source code. If present, Pulp
@@ -51,6 +51,10 @@ Shared Variables:
 -----------------
 
 * `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+
+* `prereq_pip_packages`: Additional pip packages to install in the virtual
+  environment before installing pulp or its content plugins.
+  Defaults to an empty list, but a `prereq_role` may append to it.
 
 This role is required by the `pulp-database` role and uses some variables from it.
 

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -98,6 +98,17 @@
       register: result
       until: result is succeeded
 
+    # We are purposely running this before the venv is created, since
+    # if we are using system-wide packages, it could cause duplicate
+    # python packages to be installed.
+    # Note: We would do a static import like in pulp-database, but
+    # looping does not work with it, so we do a dynamic include.
+    - name: Include plugins prereq roles
+      include_role:
+        name: "{{ item.value.prereq_role }}"
+      with_dict: "{{ pulp_install_plugins }}"
+      when: item.value.prereq_role is defined
+
   become: true
 
 - block:


### PR DESCRIPTION
…to fail

Solution: Provide a new field within the dict pulp_install_plugins called
prereq_role . The pulp role, with its variables loaded, will dynamically
import all prereq roles.

Fixes: #5518
Problem: Running include_roles with pulp_rpm_prerequisites causes it to fail
https://pulp.plan.io/issues/5518