### PR TITLE
Story: As a user, I can install pulp 3 on a RHEL host

### DIFF
--- a/roles/pulp-database/vars/RedHat.yml
+++ b/roles/pulp-database/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml

--- a/roles/pulp-redis/vars/RedHat.yml
+++ b/roles/pulp-redis/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -46,6 +46,15 @@ Role Variables:
     docs](https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#id2) for
     documentation on the possible values.
   * `pulp_settings.secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
+* `rhel7_optional_repo`: List of possible names for the rhel7 optional repo
+  to enable. Once the 1st name is enabled (or found to already be enabled),
+  no further names are attempted.
+  Defaults to  ["rhui-rhel-7-server-rhui-optional-rpms", "rhel-7-server-optional-rpms", "rhel-7-workstation-optional-rpms"]
+  Set to an empty list `[]` if you wish to disable trying to enable the repo,
+  such as if you manually add the optional repo via your own configuration or
+  subscription-manager/katello.
+  Also accepts a single string or empty string.
+  Only affects RHEL7 (RHEL8 no longer has an optional repo.)
 
 
 Shared Variables:

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -7,7 +7,6 @@ The default administrative user for the Pulp application is: 'admin'
 
 Role Variables:
 ---------------
-
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to "/var/lib/pulp/tmp".
 * `pulp_config_dir`: Directory which will contain Pulp configuration files.
   Defaults to "/etc/pulp".
@@ -46,6 +45,16 @@ Role Variables:
     docs](https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#id2) for
     documentation on the possible values.
   * `pulp_settings.secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
+* `epel_release_packages`: List of strings (package names, URLs) to pass to
+  `yum install` to ensure that "epel-release" is installed.
+  Once the 1st string is found to be installed by yum, no further strings are
+  attempted.
+  Defaults to (on el7 for example): ["epel-release", "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"]
+  Set to an empty list `[]` if you wish to disable trying to install
+  epel-release, such as if you manually add the EPEL repo via your own
+  configuration or subscription-manager/katello.
+  Also accepts a single string or empty string.
+  Only affects CentOS/RHEL.
 * `rhel7_optional_repo`: List of possible names for the rhel7 optional repo
   to enable. Once the 1st name is enabled (or found to already be enabled),
   no further names are attempted.

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -19,3 +19,6 @@ rhel7_optional_repo:
   - rhui-rhel-7-server-rhui-optional-rpms
   - rhel-7-server-optional-rpms
   - rhel-7-workstation-optional-rpms
+epel_release_packages:
+  - epel-release
+  - "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -15,3 +15,7 @@ pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 pulp_api_bind: '127.0.0.1:24817'
 prereq_pip_packages: []
+rhel7_optional_repo:
+  - rhui-rhel-7-server-rhui-optional-rpms
+  - rhel-7-server-optional-rpms
+  - rhel-7-workstation-optional-rpms

--- a/roles/pulp/meta/main.yml
+++ b/roles/pulp/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   issue_tracker_url: https://pulp.plan.io/projects/external/issues/new
   license: GPLv2
   company: Red Hat
-  min_ansible_version: 2.2
+  min_ansible_version: 2.8
   platforms:
     - name: Debian
       versions:

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -8,11 +8,30 @@
       # This is a lie, but necessary for Idempotence test
       changed_when: False
 
+    # Break the loop once the first package name/URL in the list is found to be installed.
+    # The yum module (which wraps the yum command) uses rc=126 for package not
+    # found, or 0 for changed / already installed.
     - name: Install EPEL Release
-      package:
-        name: epel-release
+      yum:
+        name: "{{ item }}"
         state: present
-      when: ansible_distribution == 'CentOS'
+        # dnf/yum4 registered results not implemented yet
+        use_backend: yum
+      register: epel
+      when:
+        - (ansible_distribution == 'CentOS') or (ansible_distribution == 'RedHat')
+        # Works for both strings and lists to make sure not empty
+        - epel_release_packages is defined
+        - epel_release_packages is not none
+        - epel_release_packages | length > 0
+        - ( ansible_loop.first ) or (epel.rc == 126)
+      failed_when:
+        - epel.rc not in [0,126]
+        - ( ansible_loop.last ) and (epel.rc == 126)
+      # Cast a single string as a list.
+      loop: "{{ lookup('vars', 'epel_release_packages', wantlist=True) }}"
+      loop_control:
+        extended: True
 
     - name: Install prerequisites
       package:

--- a/roles/pulp/tasks/main.yml
+++ b/roles/pulp/tasks/main.yml
@@ -28,6 +28,19 @@
   set_fact:
     default_bin_path: "{{ systemd_show_env_path }}"
 
+# Try multiple possible names for the rhel7 optional repo until it is found.
+# The query ensures that a single string rather than a list of strings is valid.
+- include_tasks: rhel7-optional.yml
+  with_items: "{{ rhel7_optional_repo }}"
+  when:
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version|int == 7
+    # Works for both strings and lists to make sure not empty
+    - rhel7_optional_repo is not none
+    - rhel7_optional_repo | length > 0
+    # Prevents running again once completed.
+    - optional_repo_enabled is not defined
+
 - import_tasks: install.yml
 - import_tasks: configure.yml
 - import_tasks: wsgi.yml

--- a/roles/pulp/tasks/rhel7-optional.yml
+++ b/roles/pulp/tasks/rhel7-optional.yml
@@ -1,0 +1,18 @@
+---
+- name: Determine which in /etc/yum.repos.d/ has the repo
+  command: grep -l -E "^\[{{ item }}\]" /etc/yum.repos.d/*.repo -R
+  register: repo_file
+  changed_when: false
+  failed_when: false
+  check_mode: False
+
+- name: Enable the repo
+  ini_file:
+    path: "{{ repo_file.stdout }}"
+    section: "{{ item }}"
+    option: enabled
+    value: 1
+    no_extra_spaces: true
+  when: repo_file.rc == 0
+  register: optional_repo_enabled
+  become: true

--- a/roles/pulp/vars/Fedora.yml
+++ b/roles/pulp/vars/Fedora.yml
@@ -2,8 +2,8 @@
 pulp_preq_packages:
   - python3
   - python3-devel
-  - libselinux-python  # For ansible itself
-  - make               # For make docs
+  - python3-libselinux  # For ansible itself
+  - make                # For make docs
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp/vars/RedHat.yml
+++ b/roles/pulp/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml


### PR DESCRIPTION
This is a bit over-engineered, but it provides a flexible interface via a single variable. And an easy way to add other possible/likely names for the optional repo.

I am thinking of refactoring epel and rhel7 optional into another role. Like "pulp-dependency-repos".

This also currently requires that the pulp-rpm-prerequisites not be manually run before the pulp role on RHEL7, unless epel-release was already installed.

I also think the variable names are inconsistent: singlular repo vs plural packages.

I based this on https://github.com/pulp/ansible-pulp/pull/173 , which fixes CI failures.