### PR TITLE
Problem: ansible-pulp fails to disable SELinux on F30

### DIFF
--- a/roles/pulp/vars/Fedora.yml
+++ b/roles/pulp/vars/Fedora.yml
@@ -2,8 +2,8 @@
 pulp_preq_packages:
   - python3
   - python3-devel
-  - libselinux-python  # For ansible itself
-  - make               # For make docs
+  - python3-libselinux  # For ansible itself
+  - make                # For make docs
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
with the error:
fatal: [fedora-30]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libselinux-python) on fedora-30's Python /usr/bin/python3. Please read module documentation and install in the appropriate location"}

Solution: install python3-libselinux rather than libselinux-python,
which is obsoleted by python2-libselinux. Since we use python3
as Fedora's ansible interpreter.

[noissue]