### PR TITLE
Problem: Ansible gives a poor error message when its version is too old

### DIFF
--- a/example-source/playbook.yml
+++ b/example-source/playbook.yml
@@ -1,5 +1,13 @@
 ---
 - hosts: all
+  pre_tasks:
+    # The version string below is the highest of all those in roles' metadata:
+    # "min_ansible_version". It needs to be kept manually up-to-date.
+    - name: Verify Ansible meets min required version
+      assert:
+        that: "ansible_version.full is version_compare('2.8', '>=')"
+        msg: >
+          "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
     - pulp-database
     - pulp-workers

--- a/example-use/playbook.yml
+++ b/example-use/playbook.yml
@@ -1,5 +1,13 @@
 ---
 - hosts: all
+  pre_tasks:
+    # The version string below is the highest of all those in roles' metadata:
+    # "min_ansible_version". It needs to be kept manually up-to-date.
+    - name: Verify Ansible meets min required version
+      assert:
+        that: "ansible_version.full is version_compare('2.8', '>=')"
+        msg: >
+          "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
     - pulp-database
     - pulp-workers


### PR DESCRIPTION
and it sees new syntax.

Solution: Add a pre_task to check the ansible version.

re: #5558
Add ansible-pulp logic to grab epel-release from the internet
https://pulp.plan.io/issues/5558

[noissue]