### PR TITLE
Problem: ansible-pulp cannot be run a 2nd time against F30

### DIFF
--- a/roles/pulp-database/README.md
+++ b/roles/pulp-database/README.md
@@ -25,6 +25,8 @@ Shared Variables:
 -----------------
 
 * `ansible_python_interpreter`: **Required**. Path to the Python interpreter.
+  This role sets the default to "auto", which is now more robust than
+  "auto_legacy" on Ansible 2.8.
 
 This role **is tightly coupled** with the required the `pulp` role and uses some of
 variables which are documented in that role:

--- a/roles/pulp-database/defaults/main.yml
+++ b/roles/pulp-database/defaults/main.yml
@@ -10,3 +10,8 @@ pulp_settings_db_defaults:
             NAME: pulp
             USER: pulp
             PASSWORD: pulp
+# Auto is more robust for us than auto_legacy (still the default as of 2.8)
+# because the geerlingguy.postgresql role, with RPM weak deps, installs
+# /usr/bin/python pointing to python2, on Fedora 30. This in turn breaks
+# running ansible-pulp a 2nd time, because F30 lacks python2-dnf.
+ansible_python_interpreter: auto


### PR DESCRIPTION
It fails because it uses python2, and cannot find python2-dnf.

Solution: Set the default to the new "auto" ansible_python_interpreter
discovery method.

[noissue]