### PR TITLE
Problem: RHEL7 optional repo does not get enabled

### DIFF
--- a/roles/pulp/tasks/rhel7-optional.yml
+++ b/roles/pulp/tasks/rhel7-optional.yml
@@ -1,6 +1,6 @@
 ---
 - name: Determine which in /etc/yum.repos.d/ has the repo
-  command: grep -l -E "^\[{{ item }}\]" /etc/yum.repos.d/*.repo -R
+  shell: grep -l -E "^\[{{ item }}\]" /etc/yum.repos.d/*.repo
   register: repo_file
   changed_when: false
   failed_when: false


### PR DESCRIPTION
Due to the command module not expanding asterisks in file paths

Solution: Switch to shell module. Also drop unnecessary -R recursion.

[noissue]