### PR TITLE
Problem: geerlingguy.postgresql fails on F29

### DIFF
--- a/roles/pulp-database/vars/Fedora.yml
+++ b/roles/pulp-database/vars/Fedora.yml
@@ -1,2 +1,3 @@
 ---
+# TODO: This var is now overriden within geerlingguy.postgresql instead.
 postgresql_python_library: python3-psycopg2

--- a/roles/pulp/vars/Fedora.yml
+++ b/roles/pulp/vars/Fedora.yml
@@ -3,6 +3,7 @@ pulp_preq_packages:
   - python3
   - python3-devel
   - python3-libselinux  # For ansible itself
+  - python3-psycopg2    # Since geerlingguy.postgresql installs python2- on F29
   - make                # For make docs
 
 # Pulp requires Python 3.6+.


### PR DESCRIPTION
Due to it installing and using python2-psycopg2 rather than python3-psycopg2
with F29's python3 ansible_python_interpeter, and ignoring the var we set
for the role (postgresql_python_library).

Solution: Workaround by installing the psycopg2 package in the pulp role in
Fedora, like we do for other distros currently.

[noissue]