### PR TITLE
Problem: Travis CI idempotency tests fail on postgresql unix socket dirs

### DIFF
--- a/molecule/scenario_resources/Dockerfile.j2
+++ b/molecule/scenario_resources/Dockerfile.j2
@@ -3,8 +3,14 @@
 # This Dockerfile prepares the image for {{ item.image }} to be used in molecule tests for the
 # ansible-pulp role. The main process should be systemd, to mimic an installation where services
 # can be installed and controlled. Systemd seems to be able to detect that it is being run in a
-# container context, and starts very little services. There is no need to delete any files from
-# /{etc,lib}/systemd/*.
+# container context, and starts very few services. There is generally no need to delete any
+# files from /{etc,lib}/systemd/*. Exceptions though:
+#
+# /usr/lib/tmpfiles.d/postgresql.conf
+# Workaround geerlingguy.postgresql setting different perms on
+# /var/run/postgresql than Fedora & derivatives want.
+# A timer than runs 15 mins since boot makes little sense for a container
+# anyway. It's not a persistent system.
 
 FROM {{ item.image }}
 
@@ -28,7 +34,8 @@ yum install -y \
   yum-plugin-ovl \
   ;\
 sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf ;\
-yum clean all
+yum clean all ;\
+echo 'd /var/run/postgresql 2775 postgres postgres -' >  /etc/tmpfiles.d/postgresql.conf
 {% elif item.name.startswith('debian') -%}
 
 ENV LC_ALL C
@@ -70,7 +77,8 @@ dnf --assumeyes install \
   sudo \
   which \
   ;\
-dnf clean all
+dnf clean all ;\
+echo 'd /var/run/postgresql 2775 postgres postgres -' >  /etc/tmpfiles.d/postgresql.conf
 {%- endif %}
 
 # Disable requiretty.


### PR DESCRIPTION
Because 15 mins after the container gets started, the systemd timer
for tmpfiles runs and resets perms on /var/run/postgresql, which
geerlingguy.postgresql changes.

Solution: In molecule, make the tmpfiles config match the values of the role.

[noissue]