### PR TITLE
Adds the PULP_SETTINGS Env Var

### DIFF
--- a/roles/pulp-content/templates/pulpcore-content.service.j2
+++ b/roles/pulp-content/templates/pulpcore-content.service.j2
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-content/

--- a/roles/pulp-database/tasks/main.yml
+++ b/roles/pulp-database/tasks/main.yml
@@ -41,3 +41,5 @@
 
   become: true
   become_user: '{{ pulp_user }}'
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"

--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -132,8 +132,8 @@
         create: yes
 
     - name: Add Django supplemental bashrc
-      copy:
-        src: files/django.bashrc
+      template:
+        src: templates/django.bashrc.j2
         dest: '{{ developer_user_home }}/.bashrc.d/django.bashrc'
       when: pulp_devel_supplement_bashrc
 

--- a/roles/pulp-devel/templates/django.bashrc.j2
+++ b/roles/pulp-devel/templates/django.bashrc.j2
@@ -1,1 +1,2 @@
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+export PULP_SETTINGS={{ pulp_settings_file }}

--- a/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.j2
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/

--- a/roles/pulp-workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulpcore-worker@.service.j2
@@ -7,6 +7,7 @@ Wants=network-online.target
 EnvironmentFile=-/etc/default/pulp-workers
 EnvironmentFile=-/etc/default/pulp-workers-%i
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 User={{ pulp_user }}
 Group={{ pulp_group }}

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -2,6 +2,9 @@
 
 pulp_cache_dir: '/var/lib/pulp/tmp'
 pulp_config_dir: '/etc/pulp'
+# This var intentionally not advertised to users, because there is no
+# foreseeable need for them to change the filename, only pulp_config_dir.
+pulp_settings_file: '{{ pulp_config_dir }}/settings.py'
 pulp_default_admin_password: ''
 pulp_install_dir: '/usr/local/lib/pulp'
 pulp_install_plugins: {}

--- a/roles/pulp/handlers/main.yml
+++ b/roles/pulp/handlers/main.yml
@@ -14,3 +14,5 @@
   become: true
   become_user: '{{ pulp_user }}'
   notify: Restart pulpcore-api.service
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"

--- a/roles/pulp/tasks/configure.yml
+++ b/roles/pulp/tasks/configure.yml
@@ -16,7 +16,7 @@
     - name: Create configuration file for Pulp
       template:
         src: settings.py.j2
-        dest: '{{ pulp_config_dir }}/settings.py'
+        dest: '{{ pulp_settings_file }}'
         owner: root
         group: '{{ pulp_group }}'
         mode: 0640

--- a/roles/pulp/templates/pulpcore-api.service.j2
+++ b/roles/pulp/templates/pulpcore-api.service.j2
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
+Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 User={{ pulp_user }}
 PIDFile=/run/pulpcore-api.pid


### PR DESCRIPTION
Sets it in:
- systemd units
- pulp-devel role bash script
- Any task/handler that calls django-admin

https://pulp.plan.io/issues/5560
closes #5560

This PR replaces: https://github.com/pulp/ansible-pulp/pull/181