### PR TITLE
Add pulp_settings.content_origin to the example vars files.

### DIFF
--- a/example-source/group_vars/all
+++ b/example-source/group_vars/all
@@ -8,3 +8,4 @@ developer_user_home: /var/lib/pulp
 developer_user: pulp
 pulp_settings:
   secret_key: secret
+  content_origin: "http://{{ ansible_fqdn }}"

--- a/example-use/group_vars/all
+++ b/example-use/group_vars/all
@@ -4,3 +4,4 @@ pulp_install_plugins:
   pulp-file: {}
 pulp_settings:
   secret_key: secret
+  content_origin: "http://{{ ansible_fqdn }}"

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -48,6 +48,12 @@ Role Variables:
     dictionary are variable names, and the values can be nested. Please see [pulpcore configuration
     docs](https://docs.pulpproject.org/en/3.0/nightly/installation/configuration.html#id2) for
     documentation on the possible values.
+  * `pulp_settings.content_origin`: **Required**. The URL to the pulp-content
+    host that clients will access, and that will be appended to in HTTP
+    responses by multiple content plugins. Any load balancers / proxies (such
+    as those in the `pulp-webserver` role) normally should be specified instead
+    of the pulp content host itself. Syntax is
+    `(http|https)://(hostname|ip)[:port]`.
   * `pulp_settings.secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
 * `epel_release_packages`: List of strings (package names, URLs) to pass to
   `yum install` to ensure that "epel-release" is installed.


### PR DESCRIPTION
I'd like feedback on this approach (vars files vs in the `pulp` role or `pulp-webserver` role), and the README.md wording.

(Still testing this too.)

(Relies on setup module being run to parse ansible_fqdn).
And document it in the pulp role as well.

Fixes: #5648
Add CONTENT_ORIGIN to the installer
https://pulp.plan.io/issues/5648