### PR TITLE
Switch from psycogp2-binary to psycopg2

### DIFF
--- a/roles/pulp-database/vars/CentOS.yml
+++ b/roles/pulp-database/vars/CentOS.yml
@@ -1,6 +1,4 @@
 ---
-postgresql_python_library: python-psycopg2
-
 # vars needed for 'rh-postgresql96' SCL
 postgresql_packages: rh-postgresql96
 postgresql_daemon: rh-postgresql96-postgresql

--- a/roles/pulp-database/vars/Fedora.yml
+++ b/roles/pulp-database/vars/Fedora.yml
@@ -1,3 +1,1 @@
 ---
-# TODO: This var is now overriden within geerlingguy.postgresql instead.
-postgresql_python_library: python3-psycopg2

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -38,14 +38,6 @@
         name: '{{ pulp_preq_packages }}'
         state: present
 
-    # Needed by psycopg2-binary from PyPI
-    - name: Install prerequisites (Fedora 30+ only)
-      package:
-        name: libxcrypt-compat
-        state: present
-      when:
-        - ansible_distribution == "Fedora"
-
     - name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
       selinux:
         policy: targeted
@@ -147,13 +139,6 @@
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
         virtualenv_site_packages: yes
       when: pulp_use_system_wide_pkgs |bool
-
-    - name: Install the psycopg python package
-      pip:
-        name: psycopg2-binary
-        state: present
-        virtualenv: '{{ pulp_install_dir }}'
-        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
     - name: Install the prereq_pip_packages
       pip:

--- a/roles/pulp/vars/CentOS.yml
+++ b/roles/pulp/vars/CentOS.yml
@@ -4,7 +4,8 @@ pulp_preq_packages:
   - python36-devel
   - python-setuptools
   - libselinux-python  # For ansible itself
-  - python-psycopg2
   - python-contextlib2
+  - postgresql-devel
+  - gcc                # For psycopg2
   - make               # For make docs
 pulp_python_interpreter: /usr/bin/python3.6

--- a/roles/pulp/vars/Debian.yml
+++ b/roles/pulp/vars/Debian.yml
@@ -1,7 +1,10 @@
 ---
 pulp_preq_packages:
   - python3
+  - python3-dev
   - python3-venv
+  - libpq-dev
+  - gcc              # For psycopg2
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp/vars/Fedora.yml
+++ b/roles/pulp/vars/Fedora.yml
@@ -3,8 +3,9 @@ pulp_preq_packages:
   - python3
   - python3-devel
   - python3-libselinux  # For ansible itself
-  - python3-psycopg2    # Since geerlingguy.postgresql installs python2- on F29
+  - gcc                 # For psycopg2
   - make                # For make docs
+  - libpq-devel         # Renamed/Split version of postgresql-devel
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp/vars/Ubuntu.yml
+++ b/roles/pulp/vars/Ubuntu.yml
@@ -1,7 +1,10 @@
 ---
 pulp_preq_packages:
   - python3
+  - python3-dev
   - python3-venv
+  - libpq-dev
+  - gcc                 # For psycopg2
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Also cleans up old and psycopg2-binary workarounds.

Corresponds to:
https://github.com/pulp/pulpcore/pull/378

[noissue]