### PR TITLE
Problem: ansible-pulp fails to install epel-release on CentOS7

### DIFF
--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -25,11 +25,12 @@
         - epel_release_packages is not none
         - epel_release_packages | length > 0
         - ( ansible_loop.first ) or (epel.rc == 126)
-      failed_when:
-        - epel.rc not in [0,126]
-        - ( ansible_loop.last ) and (epel.rc == 126)
-      # Cast a single string as a list.
-      loop: "{{ lookup('vars', 'epel_release_packages', wantlist=True) }}"
+      failed_when: (epel.rc not in [0,126]) or
+                   (( ansible_loop.last ) and (epel.rc == 126))
+      # Cast a single string as a list so that the loop will work.
+      # This will also convert a list to a list with 1 list in it, so flatten it
+      # so that the yum task will only operate on 1 item at a time.
+      loop: "{{ lookup('vars', 'epel_release_packages', wantlist=True) | flatten }}"
       loop_control:
         extended: True
 


### PR DESCRIPTION
When the epel-release version in CentOS is older than the version on
the internet-accessible URL.

solution: Fix the loop trying only 1 item at a time.

Also fix the related issue of it not counting yum rc 1 as an error.

fixes: #5705
ansible-pulp fails to install epel-release on CentOS7
https://pulp.plan.io/issues/5705