### PR TITLE
Workers no longer specify a name

### DIFF
--- a/roles/pulp-workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp-workers/templates/pulpcore-worker@.service.j2
@@ -15,7 +15,6 @@ WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
-          -n reserved-resource-worker-%i@%%h \
           --pid=/var/run/pulpcore-worker-%i/reserved-resource-worker-%i.pid \
           -c 'pulpcore.rqconfig' \
           --disable-job-desc-logging


### PR DESCRIPTION
A feature was added to have workers auto-name themselves with
{pid}@{hostname}. By not specifying the ``-n`` option, each process will
receive its name automatically.

Required PR: https://github.com/pulp/pulpcore/pull/414

https://pulp.plan.io/issues/5787
closes #5787