### PR TITLE
Problem: ansible-pulp CI fails due to idempotence test taking 10+ mins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ deps =
     docker
     molecule
 commands =
-    molecule test --all
+    molecule --debug test --all


### PR DESCRIPTION
Solution: Run molecule with --debug

For the test sequence, since there is no easy way to add debug only for the idempotence test.