### PR TITLE
Problem: ansible-pulp CI fails due to idempotence test taking 10+ mins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ matrix:
 install:
   - pip install --upgrade pip
   - pip install tox
+  # Much easier than trying to use the travis_wait bash function in tox.
+  - wget -qO- https://github.com/crazy-max/travis-wait-enhanced/releases/download/v1.0.0/travis-wait-enhanced_1.0.0_linux_x86_64.tar.gz | sudo tar -C /usr/local/bin -zxvf - travis-wait-enhanced
 script:
-  - tox
+  - TRAVIS_WAIT="travis-wait-enhanced --timeout=20m --" tox

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,35 @@ deps =
     ansible
     docker
     molecule
+passenv = TRAVIS_WAIT
+whitelist_externals =
+    travis-wait-enhanced
+# For reference on the commands, see:
+# `molecule matrix test`
+# We removed cleanup and destroy from the middle it breaks later tasks.
+# We removed cleanup and destroy from the end because they complicate Travis
+# debugging.
 commands =
-    molecule test --all
+    molecule lint -s default
+    molecule dependency -s default
+    molecule syntax -s default
+    molecule create -s default
+    molecule prepare -s default
+    molecule converge -s default
+    # There is no output while the idempotence test runs, so prevent Travis
+    # from failing when the idempotence test takes longer than Travis's normal
+    # 10 minute wait for output.
+    # NOTE: --debug would only provide output for seconds at the beginning
+    # and end.
+    {env:TRAVIS_WAIT:} molecule idempotence -s default
+    molecule side-effect -s default
+    molecule verify -s default
+    molecule lint -s source
+    molecule dependency -s source
+    molecule syntax -s source
+    molecule create -s source
+    molecule prepare -s source
+    molecule converge -s source
+    {env:TRAVIS_WAIT:} molecule idempotence -s source
+    molecule side-effect -s source
+    molecule verify -s source


### PR DESCRIPTION
Solution: Use a travis_wait of 20 mins for the idempotence test.

Implementation includes:
1. Calling the molecule scenarios & test sequences individually
2. Not calling cleanup or destroy at the end (never needed, and interfere
with Travis debugging anyway.)
3. Using a defaults-to-empty-string TRAVIS_WAIT env var in tox.ini .
4. Installing an open source go binary, travis-wait-enhanced.
(travis_wait is a bash function, so it cannot be used inside tox.)

Fixes: #5811
https://pulp.plan.io/issues/5811
ansible-pulp CI fails due to idempotence test taking 10+ mins