### PR TITLE
Molecule: Enable Ansible pipelining via group_vars

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -36,6 +36,7 @@ provisioner:
   inventory:
     links:
       host_vars: ../scenario_resources/host_vars/
+      group_vars: ../scenario_resources/group_vars/
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/scenario_resources/group_vars/all
+++ b/molecule/scenario_resources/group_vars/all
@@ -1,0 +1,2 @@
+---
+ansible_ssh_pipelining: True

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -32,6 +32,7 @@ provisioner:
   inventory:
     links:
       host_vars: ../scenario_resources/host_vars/
+      group_vars: ../scenario_resources/group_vars/
   lint:
     name: ansible-lint
 scenario:


### PR DESCRIPTION
Variables are currently sufficient for enabling pipelining in molecule
because the role we tried (gzm55.smart_ssh_pipelining) did not need
to modify system configuration for all 3 containers; it only set
the variable.

Fixes: #5817
ansible-pulp CI is slower than it should be due to a lack of ansible pipelining
[noissue]