### PR TITLE
Change resource manager name disinclude hostname

### DIFF
--- a/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp-resource-manager/templates/pulpcore-resource-manager.service.j2
@@ -11,7 +11,7 @@ User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
-          -w pulpcore.tasking.worker.PulpWorker -n resource-manager@%%h \
+          -w pulpcore.tasking.worker.PulpWorker -n resource-manager \
           --pid=/var/run/pulpcore-resource-manager/resource-manager.pid \
           -c 'pulpcore.rqconfig' \
           --disable-job-desc-logging


### PR DESCRIPTION
This is a backwards compatible change, but it will be required once
pulpcore requires the name to be exactly `resource-manager`.

https://pulp.plan.io/issues/3707
re #3707