### PR TITLE
Problem: local molecule lint fails when geerlingguy.postgresql is sym…

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,6 @@
 # systemctl subcommands that actually manage services.
 skip_list:
   - '303'
+
+exclude_paths
+  - ./roles/geerlingguy.postgresql/


### PR DESCRIPTION
…linked under roles/

Solution: Add it to the lint exclude list.

[noissue]