### PR TITLE
Make ansible-pulp's versions correspond to a specific version of pulp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Pulp 3 Ansible installer
 The Pulp 3 Ansible installer consists of a collection of roles. Each role installs and configures a
 component of Pulp. The roles are not currently available on Ansible Galaxy; to run the Pulp 3
 Ansible installer, the [ansible-pulp](https://github.com/pulp/ansible-pulp) git repository must
-be cloned.
+be cloned or downloaded.
+
+This version of the installer, 3.0.1-1, installs Pulp 3.0.1 specifically.
+
+If run against an older version of Pulp 3, it will upgrade it to 3.0.1.
 
 System Requirements
 -------------------

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -17,7 +17,8 @@ Role Variables:
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each
   plugin's* `setup.py`. **Required**.
-  * `upgrade`: Whether to update/upgrade the plugin to the latest stable release from PyPI. Only affects systems where the plugin is already installed. If `source_dir` is set, this has no effect and is effectively always `true`. Note that if the latest stable release of the plugin is incompatible with pulpcore's version, ansible-pulp will fail (and exit the play) when it goes to upgrade the plugin. Defaults to "false".
+  * `version`: Specific release of the plugin to install from PyPI, or upgrade to (regardless of whether `upgrade` is set.) If `source_dir` is set, this has no effect. Note that if the spceified release of the plugin is incompatible with pulpcore's version, ansible-pulp will fail (and exit the play) when it goes to install or upgrade the plugin. Defaults to nothing.
+  * `upgrade`: Whether to update/upgrade the plugin to the latest stable release from PyPI. Only affects systems where the plugin is already installed. If `source_dir` is set, this has no effect and is effectively always `true`. Mutually exclusive with `version`. Note that if the latest stable release of the plugin is incompatible with pulpcore's version, ansible-pulp will fail (and exit the play) when it goes to upgrade the plugin. Defaults to "false".
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
   Also accepts a pip VCS URL, to (for example) install the master branch.
@@ -27,8 +28,6 @@ Role Variables:
     See `prereq_pip_packages` also.
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulpcore-api. Defaults to "true".
-* `pulp_upgrade`: Whether to update/upgrade pulpcore to the latest stable release from PyPI. Only affects systems where Pulp is already installed. If `pulp_source_dir` is set, this has no effect and is effectively always `true`. Defaults to "false".
-* `pulp_source_dir`: Optional. Absolute path to pulpcore source code. If
   present, pulpcore will be installed from source in editable mode. Also accepts
   a pip VCS URL, to (for example) install the master branch.
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
@@ -100,7 +99,6 @@ directory.
 Idempotency:
 ------------
 This role is idempotent by default. It is dependent on these settings remaining `false`:
-* `pulp_upgrade`
 * Every `upgrade` under `pulp_install_plugins`
 
 License

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -18,7 +18,13 @@ pulp_settings_db_defaults:
 pulp_install_dir: '/usr/local/lib/pulp'
 pulp_install_plugins: {}
 pulp_install_api_service: true
+# Deprecated unused. Variables for dependency upgrades are TBD
 pulp_upgrade: false
+#  Intentionally not advertised to users. They should not set this unless
+#  they are confident that this version of ansible-pulp is compatible with
+#  pulp_version.
+#  Ignored if pulp_source_dir is set
+pulp_version: "3.0.1"
 pulp_user: pulp
 pulp_user_id:
 pulp_group: pulp

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -182,7 +182,7 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
         virtualenv_site_packages: yes
-      when: pulp_use_system_wide_pkgs |bool
+      when: pulp_use_system_wide_pkgs | bool
 
     - name: Install the prereq_pip_packages
       pip:
@@ -197,7 +197,11 @@
         name: pulpcore
         # pulp_upgrade true/false -> ansible pip module latest/present ->
         # pip command "install --upgrade"/"install"
-        state: "{{ pulp_upgrade | ternary('latest','present') }}"
+        # Commented out because:
+        # "version is incompatible with state=latest"
+        # But we still need to handle upgrading dependencies.
+        # state: "{{ pulp_upgrade | ternary('latest','present') }}"
+        version: '{{ pulp_version }}'
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       when: pulp_source_dir is undefined
@@ -244,6 +248,9 @@
         # item.upgrade true/false -> ansible pip module latest/present ->
         # pip command "install --upgrade"/"install"
         state: "{{ item.upgrade | default(false) | ternary('latest','present','present') }}"
+        # TODO: Handle the fact that "version is incompatible with state=latest"
+        # through proper means, rather than just telling users not to set both.
+        version: '{{ item.value.version | default(omit) }}'
         extra_args: "-c {{ pulp_install_dir }}/pip_constraints_for_plugins.txt"
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
@@ -264,7 +271,7 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       with_dict: '{{ pulp_install_plugins }}'
-      when: pulp_install_plugins[item.key].source_dir is defined
+      when: item.value.source_dir is defined
       register: result
       # This is a hack. Editable pip installs are always changed, which fails molecule's
       # idempotence test.


### PR DESCRIPTION
…core

Currently, 3.0.1

fixes: #6072
Make ansible-pulp's versions correspond to a specific version of pulpcore

@mdellweg Note that I changed the variable name from pulpcore_version to pulp_version for consistency. I think multiple variables should be renamed to pulpcore, and we should do that for the next Y-release.