### PR TITLE
Problem: ansible-pulp fails to upgrade plugins via the upgrade variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ component of Pulp. The roles are not currently available on Ansible Galaxy; to r
 Ansible installer, the [ansible-pulp](https://github.com/pulp/ansible-pulp) git repository must
 be cloned or downloaded.
 
-This version of the installer, 3.0.1-1, installs Pulp 3.0.1 specifically.
+This version of the installer, 3.0.1-2, installs Pulp 3.0.1 specifically.
 
 If run against an older version of Pulp 3, it will upgrade it to 3.0.1.
 

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -247,7 +247,7 @@
         name: '{{ item.key }}'
         # item.upgrade true/false -> ansible pip module latest/present ->
         # pip command "install --upgrade"/"install"
-        state: "{{ item.upgrade | default(false) | ternary('latest','present','present') }}"
+        state: "{{ item.value.upgrade | default(false) | ternary('latest','present','present') }}"
         # TODO: Handle the fact that "version is incompatible with state=latest"
         # through proper means, rather than just telling users not to set both.
         version: '{{ item.value.version | default(omit) }}'


### PR DESCRIPTION
Solution: call item.key.upgrade rather than item.upgrade in the ansible
task that uses the pulp_install_plugins data structure.

fixes: 6078
ansible-pulp fails to upgrade plugins via the upgrade variable
https://pulp.plan.io/issues/6078