### PR TITLE
Add missing package retries to pulp-devel Role

### DIFF
--- a/roles/pulp-devel/tasks/main.yml
+++ b/roles/pulp-devel/tasks/main.yml
@@ -27,6 +27,9 @@
           - python-virtualenvwrapper
           - podman
           - ruby-devel
+      retries: "{{ pulp_devel_package_retries }}"
+      register: result
+      until: result is succeeded
       when: ansible_distribution == 'CentOS'
 
     - name: Ensure podman apt key is present (Debian-specific)


### PR DESCRIPTION
I just noticed there is one task using the package module that does not perform any retries. All other tasks using the module do perform retries.

If this is intentional feel free to close this PR (though I would like an explanation :wink:).