### PR TITLE
Use the pulp-fixtures container

### DIFF
--- a/roles/pulp-devel/files/settings.json
+++ b/roles/pulp-devel/files/settings.json
@@ -31,5 +31,8 @@
     ],
     "selinux enabled": false,
     "version": "3"
+  },
+  "custom": {
+    "fixtures_origin": "http://localhost:8000/fixtures/"
   }
 }

--- a/roles/pulp-devel/tasks/install_podman.yml
+++ b/roles/pulp-devel/tasks/install_podman.yml
@@ -28,4 +28,20 @@
   args:
     creates: /etc/containers
   when: ansible_distribution == 'Debian'
+
+# Needed to allow non-root users to run podman containers on Debian
+- name: Enable unprivileged_userns_clone (Debian specific)
+  sysctl:
+    name: kernel.unprivileged_userns_clone
+    value: "1"
+  when:
+    - ansible_distribution == 'Debian'
+    - ansible_virtualization_type != 'docker'
+
+# Needed to allow non-root users to run podman containers on CentOS
+- name: Set max_user_namespaces (CentOS specific)
+  sysctl:
+    name: user.max_user_namespaces
+    value: "15000"
+  when: ansible_distribution == 'CentOS'
 ...

--- a/roles/pulp-devel/templates/alias.bashrc.j2
+++ b/roles/pulp-devel/templates/alias.bashrc.j2
@@ -145,6 +145,11 @@ pyclean () {
 }
 _pyclean_help="Cleanup extra python files"
 
+pfixtures () {
+    podman run --rm -p 8000:80 quay.io/pulp/pulp-fixtures:latest
+}
+_pfixtures_help="Run pulp-fixtures container in foreground"
+
 pbindings(){
     CURRENT_DIR=$(pwd)
 
@@ -162,7 +167,7 @@ pbindings(){
 
     if [ $1 != 'pulpcore' ]
     then
-        sudo ./generate.sh pulpcore $2
+        ./generate.sh pulpcore $2
         case $2 in
             python)
                 pip install ./pulpcore-client
@@ -178,10 +183,10 @@ pbindings(){
                 echo "Sorry, language not supported"
                 ;;
         esac
-        sudo rm -rf pulpcore-client
+        rm -rf pulpcore-client
     fi
 
-    sudo ./generate.sh $@
+    ./generate.sh $@
     case $2 in
         python)
             pip install ./$1-client
@@ -197,7 +202,7 @@ pbindings(){
             echo "Sorry, language not supported"
             ;;
     esac
-    sudo rm -rf $1-client
+    rm -rf $1-client
 
     sed -i 's/podman/docker/g' generate.sh
     cd $CURRENT_DIR


### PR DESCRIPTION
Introduces the `pfixtures` command for running a local fixtures-container.

~~The container image is pulled during provisioning.~~

We are also running the container as the pulp_user instead of root. This has also been changed for the bindings container.