### PR TITLE
Add snippet chain-loading to nginx and apache

### DIFF
--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -10,6 +10,8 @@ and pulpcore-content Gunicorn processes.
 Variables:
 ----------
 
+* `pulp_webserver_server` Set the webserver Pulp should use to reverse proxy with. Defaults to
+  'nginx'.
 * `pulp_content_port` Set the port the reverse proxy should connect to for the Content app. Defaults
   to '24816'.
 * `pulp_content_host` Set the host the reverse proxy should connect to for the Content app. Defaults
@@ -21,6 +23,38 @@ Variables:
 * `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
   and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
 
+Plugin Webserver Configs:
+-------------------------
+
+The installer symlinks config fragments from plugin Python packages to either nginx or apache during
+installation. These fragments typically provide additional url routing to either the Pulp API or
+Pulp Content App. pulp_ansible has an example of such configs [here](https://github.com/pulp/
+pulp_ansible/tree/master/pulp_ansible/app/webserver_snippets).
+
+The Nginx config provides definitions for the location of the Pulp Content App and the Pulp API as
+pulp-api and pulp-content respectively. To route the url `/pulp_ansible/galaxy/` to the Pulp API you
+could use this definition in a snippet like:
+
+```
+location /pulp_ansible/galaxy/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $http_host;
+    # we don't want nginx trying to do something clever with
+    # redirects, we set the Host: header above already.
+    proxy_redirect off;
+    proxy_pass http://pulp-api;
+}
+```
+
+The Apache config provides variables containing the location of the Pulp Content App and the Pulp
+API as pulp-api and pulp-content respectively. Below is an equivalent snippet to the one above, only
+for Apache:
+
+```
+ProxyPass /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy
+ProxyPassReverse /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy
+```
 
 Shared variables:
 -----------------

--- a/roles/pulp-webserver/templates/nginx.conf.j2
+++ b/roles/pulp-webserver/templates/nginx.conf.j2
@@ -23,9 +23,12 @@ http {
     # to build optimal hash types.
     types_hash_max_size 4096;
 
-    upstream pulp {
-         server {{ pulp_api_host }}:{{ pulp_api_port }};
+    upstream pulp-content {
          server {{ pulp_content_host }}:{{ pulp_content_port }};
+    }
+
+    upstream pulp-api {
+         server {{ pulp_api_host }}:{{ pulp_api_port }};
     }
 
     server {
@@ -62,24 +65,11 @@ http {
             proxy_pass http://{{ pulp_api_host }}:{{ pulp_api_port }};
         }
 
+        include conf.d/*;
+
         location / {
             # checks for static file, if not found proxy to app
-            try_files $uri @proxy_to_app;
-        }
-
-        location @proxy_to_app {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $http_host;
-            # we don't want nginx trying to do something clever with
-            # redirects, we set the Host: header above already.
-            proxy_redirect off;
-            proxy_pass http://pulp;
-
-            # This routes to both the pulpcore-content and the pulpcore-api
-            # as if they are one service because both services allow for
-            # plugin writers to configure arbitrary url handlers.
-            proxy_next_upstream http_404;  # Try the other service upon 404
+            try_files $uri =404;
         }
     }
 }

--- a/roles/pulp-webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp-webserver/templates/pulp-vhost.conf.j2
@@ -1,3 +1,6 @@
+Define pulp-content {{ pulp_content_host }}:{{ pulp_content_port }}
+Define pulp-api {{ pulp_api_host }}:{{ pulp_api_port }}
+
 <VirtualHost *:80>
   ServerName {{ ansible_nodename }}
 
@@ -18,12 +21,13 @@
   ## Proxy rules
   ProxyRequests Off
   ProxyPreserveHost Off
-  ProxyPass /pulp/api http://{{ pulp_api_host }}:{{ pulp_api_port }}/pulp/api
-  ProxyPassReverse /pulp/api http://{{ pulp_api_host }}:{{ pulp_api_port }}/pulp/api
-  ProxyPass /pulp/content http://{{ pulp_content_host }}:{{ pulp_content_port }}/pulp/content
-  ProxyPassReverse /pulp/content http://{{ pulp_content_host }}:{{ pulp_content_port }}/pulp/content
 
-  ## Server aliases
-  ServerAlias pulp
+  ProxyPass /pulp/api http://${pulp-api}/pulp/api
+  ProxyPassReverse /pulp/api http://${pulp-api}/pulp/api
+
+  ProxyPass /pulp/content http://${pulp-content}/pulp/content
+  ProxyPassReverse /pulp/content http://${pulp-content}/pulp/content
+
+  IncludeOptional pulp/*.conf
 
 </VirtualHost>


### PR DESCRIPTION
The Nginx and Apache configs now chain-load other config files. This
includes additional documentation on the contents of those snippets.

https://pulp.plan.io/issues/6206
closes #6206