### PR TITLE
Fix phelp alias

### DIFF
--- a/roles/pulp-devel/templates/alias.bashrc.j2
+++ b/roles/pulp-devel/templates/alias.bashrc.j2
@@ -113,7 +113,7 @@ _populate_pulp2_help="Reset Pulp 2 and sync ISO, RPM, Docker repos."
 
 phelp() {
     # get a list of declared functions, filter out ones with leading underscores as "private"
-    funcs=$(declare -F | awk '{ print $3 }'| grep -v ^_)
+    funcs=$(declare -F | awk '{ print $3 }'| grep -v ^_ | grep -v fzf)
 
     # for each func, if a help string is defined, assume it's a pulp function and print its help
     # (this is bash introspection via variable variables)


### PR DESCRIPTION
[vagrant@pulp3-source-fedora30 ~]$ phelp
-bash: _fzf-file-widget_help: invalid variable name

[noissue]