### PR TITLE
Problem: In ansible-pulp CI, pip builds often fail

### DIFF
--- a/molecule/default-upgrade/molecule.yml
+++ b/molecule/default-upgrade/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:

--- a/molecule/dynamic/molecule.yml
+++ b/molecule/dynamic/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:

--- a/molecule/source-dynamic/molecule.yml
+++ b/molecule/source-dynamic/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:

--- a/molecule/source-upgrade/molecule.yml
+++ b/molecule/source-upgrade/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:

--- a/molecule/source/molecule.yml
+++ b/molecule/source/molecule.yml
@@ -14,7 +14,9 @@ lint: |
   volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
   tmpfs:
-    - /tmp
+    # Fixes issues accessing .so files under /tmp during pip builds.
+    # https://github.com/docker/compose/issues/1339
+    - /tmp:exec,mode=1777
     - /run
     - /run/lock
   capabilities:


### PR DESCRIPTION
In ansible-pulp CI, pip builds often fail to access .so files under /tmp

Solution: Mount /tmp with exec in molecule.yml per:
https://github.com/docker/compose/issues/1339#issuecomment-508730544

fixes: #6266