### PR TITLE
Problem: pulp_rpm_prerequisites CI is actually installing/upgrading p…

### DIFF
--- a/molecule/source/prepare.yml
+++ b/molecule/source/prepare.yml
@@ -21,9 +21,9 @@
         version: master
         update: yes
 
-    - name: Clone pulp_file repository
+    - name: Clone pulp plugin repositories
       git:
-        repo: 'https://github.com/pulp/pulp_file.git'
+        repo: 'https://github.com/pulp/{{ item.key| replace("-", "_") }}.git'
         dest: '{{ item.value.source_dir }}'
         version: master
         update: yes


### PR DESCRIPTION
…ulp_file twice for source scenarios

Solution: Assume the pulp org, but use the plugin's name for the github repo
to clone from.

fixes: #6276