### PR TITLE
Refactoring GHA workflows

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,22 +1,17 @@
 ---
-name: Cron jobs
-on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: '15 0 * * *'
+name: Pulp PR
+on: pull_request
 jobs:
-  full_test:
+  compact_test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python: ["2.7", "3.6", "3.7"]
-        env:
-          - TEST_TYPE: static
-          - TEST_TYPE: dynamic
-          - TEST_TYPE: upgrade
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -24,21 +19,35 @@ jobs:
       - name: Install tox
         run: |
           pip install --upgrade pip
-          pip install tox
+          pip install tox requests
+      - name: Check commit message
+        env:
+          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+        run: |
+          for sha in $(curl $GITHUB_CONTEXT | jq '.[].sha' | sed 's/"//g')
+          do
+            python .github/validate_commit_message.py $sha
+            VALUE=$?
+            if [ "$VALUE" -gt 0 ]; then
+              exit $VALUE
+            fi
+          done
+        shell: bash
       - name: Set tox env for python 27
         if: matrix.python == '2.7'
-        run: echo "::set-env name=TOXENV::py27-${{ matrix.env.TEST_TYPE }}"
+        run: echo "::set-env name=TOXENV::py27-static"
       - name: Set tox env for python 36
         if: matrix.python == '3.6'
-        run: echo "::set-env name=TOXENV::py36-${{ matrix.env.TEST_TYPE }}"
+        run: echo "::set-env name=TOXENV::py36-dynamic"
       - name: Set tox env for python 37
         if: matrix.python == '3.7'
-        run: echo "::set-env name=TOXENV::py37-${{ matrix.env.TEST_TYPE }}"
-      - name: Pulling images for upgrade
-        if: matrix.env.TEST_TYPE == 'upgrade'
         run: |
           docker pull quay.io/pulp/pulp-ci-c7:3.0.0
           docker pull quay.io/pulp/pulp-ci-dbuster:3.0.0
           docker pull quay.io/pulp/pulp-ci-f31:3.0.0
+          echo "::set-env name=TOXENV::py37-upgrade"
       - name: Run tox
+        run: tox
+      - name: Retry tox if it failed
+        if: failure()
         run: tox

--- a/.github/workflows/pulp_ci.yaml
+++ b/.github/workflows/pulp_ci.yaml
@@ -1,17 +1,27 @@
 ---
 name: Pulp CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: '15 0 * * *'
 jobs:
-  compact_test:
+  full_test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python: ["2.7", "3.6", "3.7"]
+        env:
+          - TEST_TYPE: static
+          - TEST_TYPE: dynamic
+          - TEST_TYPE: upgrade
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -19,33 +29,24 @@ jobs:
       - name: Install tox
         run: |
           pip install --upgrade pip
-          pip install tox requests
-      - name: Check commit message
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
-        run: |
-          for sha in $(curl $GITHUB_CONTEXT | jq '.[].sha' | sed 's/"//g')
-          do
-            python .github/validate_commit_message.py $sha
-            VALUE=$?
-            if [ "$VALUE" -gt 0 ]; then
-              exit $VALUE
-            fi
-          done
-        shell: bash
+          pip install tox
       - name: Set tox env for python 27
         if: matrix.python == '2.7'
-        run: echo "::set-env name=TOXENV::py27-static"
+        run: echo "::set-env name=TOXENV::py27-${{ matrix.env.TEST_TYPE }}"
       - name: Set tox env for python 36
         if: matrix.python == '3.6'
-        run: echo "::set-env name=TOXENV::py36-dynamic"
+        run: echo "::set-env name=TOXENV::py36-${{ matrix.env.TEST_TYPE }}"
       - name: Set tox env for python 37
         if: matrix.python == '3.7'
+        run: echo "::set-env name=TOXENV::py37-${{ matrix.env.TEST_TYPE }}"
+      - name: Pulling images for upgrade
+        if: matrix.env.TEST_TYPE == 'upgrade'
         run: |
           docker pull quay.io/pulp/pulp-ci-c7:3.0.0
           docker pull quay.io/pulp/pulp-ci-dbuster:3.0.0
           docker pull quay.io/pulp/pulp-ci-f31:3.0.0
-          echo "::set-env name=TOXENV::py37-upgrade"
       - name: Run tox
+        run: tox
+      - name: Retry tox if it failed
+        if: failure()
         run: tox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Pulp CI](https://github.com/pulp/ansible-pulp/workflows/Pulp%20CI/badge.svg)
-![Cron jobs](https://github.com/pulp/ansible-pulp/workflows/Cron%20jobs/badge.svg)
 
 Pulp 3 Ansible installer
 ========================


### PR DESCRIPTION
As maintaining 9 workflows doesn't seem good,
I propose adding an automatic retry when job fails.

Also refactored, so we have one workflow just for pull requests, 
and another workflow for master branch health 
https://pulp.plan.io/issues/6401
closes #6401