### PR TITLE
Cloning plugins outside pulp org

### DIFF
--- a/molecule/source/prepare.yml
+++ b/molecule/source/prepare.yml
@@ -23,7 +23,7 @@
 
     - name: Clone pulp plugin repositories
       git:
-        repo: 'https://github.com/pulp/{{ item.key| replace("-", "_") }}.git'
+        repo: '{{ item.value.git_repo | default( "https://github.com/pulp/" + item.key | replace("-", "_") ) }}'
         dest: '{{ item.value.source_dir }}'
         version: master
         update: yes


### PR DESCRIPTION
It is currently trying to clone:
https://github.com/pulp/galaxy_ng.git 
instead of
https://github.com/ansible/galaxy_ng.git 